### PR TITLE
enhancement: augmenting entity and relationship extraction for research papers

### DIFF
--- a/graphrag/config/create_graphrag_config.py
+++ b/graphrag/config/create_graphrag_config.py
@@ -42,6 +42,7 @@ from graphrag.config.models.global_search_config import GlobalSearchConfig
 from graphrag.config.models.graph_rag_config import GraphRagConfig
 from graphrag.config.models.input_config import InputConfig
 from graphrag.config.models.core_concet_extraction_config import CoreConceptExtractionConfig
+from graphrag.config.models.sentence_reconstruction_config import SentenceReconstructionConfig
 from graphrag.config.models.viztree_config import VizTreeConfig
 from graphrag.config.models.llm_parameters import LLMParameters
 from graphrag.config.models.local_search_config import LocalSearchConfig
@@ -465,6 +466,22 @@ def create_graphrag_config(
                 encoding_model=encoding_model,
                 use_doc_id=entity_extraction_config.get("use_doc_id", False),
             )
+        
+        sentence_reconstruction_config = values.get("sentence_reconstruction") or {}
+        with (
+            reader.envvar_prefix(Section.sentence_reconstruction),
+            reader.use(sentence_reconstruction_config),
+        ):
+            sentence_reconstruction_model = SentenceReconstructionConfig(
+                llm=hydrate_llm_params(sentence_reconstruction_config, llm_model),
+                parallelization=hydrate_parallelization_params(
+                    sentence_reconstruction_config, llm_parallelization_model
+                ),
+                async_mode=hydrate_async_type(sentence_reconstruction_config, async_mode),
+                prompt=reader.str("prompt", Fragment.prompt_file),
+                enabled=reader.str("enabled", True),
+                strategy=sentence_reconstruction_config.get("strategy"),
+            )
 
         claim_extraction_config = values.get("claim_extraction") or {}
         with (
@@ -674,6 +691,7 @@ def create_graphrag_config(
         chunks=chunks_model,
         snapshots=snapshots_model,
         entity_extraction=entity_extraction_model,
+        sentence_reconstruction=sentence_reconstruction_model,
         claim_extraction=claim_extraction_model,
         community_reports=community_reports_model,
         core_concept_extraction=core_concept_extractions_model,
@@ -743,6 +761,7 @@ class Section(str, Enum):
     viztree = "VIZTREE"
     embedding = "EMBEDDING"
     entity_extraction = "ENTITY_EXTRACTION"
+    sentence_reconstruction = "SENTENCE_RECONSTRUCTION"
     graphrag = "GRAPHRAG"
     input = "INPUT"
     llm = "LLM"

--- a/graphrag/config/models/graph_rag_config.py
+++ b/graphrag/config/models/graph_rag_config.py
@@ -23,6 +23,7 @@ from graphrag.config.models.local_search_config import LocalSearchConfig
 from graphrag.config.models.reporting_config import ReportingConfig
 from graphrag.config.models.snapshots_config import SnapshotsConfig
 from graphrag.config.models.storage_config import StorageConfig
+from graphrag.config.models.sentence_reconstruction_config import SentenceReconstructionConfig
 from graphrag.config.models.viztree_config import VizTreeConfig
 from graphrag.config.models.summarize_descriptions_config import (
     SummarizeDescriptionsConfig,
@@ -95,6 +96,12 @@ class GraphRagConfig(LLMConfig):
         default=SnapshotsConfig(),
     )
     """The snapshots configuration to use."""
+
+    sentence_reconstruction: SentenceReconstructionConfig = Field(
+        description="The sentence reconstruction configuration to use.",
+        default=SentenceReconstructionConfig(),
+    )
+    """The sentence reconstruction configuration to use."""
 
     entity_extraction: EntityExtractionConfig = Field(
         description="The entity extraction configuration to use.",

--- a/graphrag/config/models/sentence_reconstruction_config.py
+++ b/graphrag/config/models/sentence_reconstruction_config.py
@@ -17,32 +17,27 @@ class SentenceReconstructionConfig(LLMConfig):
     prompt: str | None = Field(
         description="The sentence reconstruction prompt to use.", default=None
     )
-    sentence_reconstruction: bool = Field(
+    enabled: bool = Field(
         default=True, description="Whether to reconstruct the sentences."
     )
     strategy: dict | None = Field(
         description="Override the default entity extraction strategy", default=None
     )
     
-    # TODO: update the resolved_strategy method
-    def resolved_strategy(self, root_dir: str, encoding_model: str | None) -> dict:
+    def resolved_strategy(self, root_dir: str) -> dict:
         """Get the resolved entity extraction strategy."""
-        from graphrag.index.operations.extract_entities import (
-            ExtractEntityStrategyType,
+        from graphrag.index.operations.reconstruct_sentence import (
+            SentenceReconstructionStrategyType,
         )
         
         return self.strategy or {
-            "type": ExtractEntityStrategyType.graph_intelligence,
+            "type": SentenceReconstructionStrategyType.plain_llm,
             "llm": self.llm.model_dump(),
             **self.parallelization.model_dump(),
-            "extraction_prompt": (Path(root_dir) / self.prompt)
+            "reconstruction_prompt": (Path(root_dir) / self.prompt)
             .read_bytes()
             .decode(encoding="utf-8")
             if self.prompt
             else None,
-            "max_gleanings": self.max_gleanings,
-            # It's prechunked in create_base_text_units
-            "encoding_name": encoding_model or self.encoding_model,
-            "prechunked": True,
-            "use_doc_id": self.use_doc_id,
+            "enabled": self.enabled
         }

--- a/graphrag/config/models/sentence_reconstruction_config.py
+++ b/graphrag/config/models/sentence_reconstruction_config.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""Parameterization settings for the default configuration."""
+
+from pathlib import Path
+
+from pydantic import Field
+
+import graphrag.config.defaults as defs
+from graphrag.config.models.llm_config import LLMConfig
+
+
+class SentenceReconstructionConfig(LLMConfig):
+    """Configuration section for entity extraction."""
+
+    prompt: str | None = Field(
+        description="The sentence reconstruction prompt to use.", default=None
+    )
+    sentence_reconstruction: bool = Field(
+        default=True, description="Whether to reconstruct the sentences."
+    )
+    strategy: dict | None = Field(
+        description="Override the default entity extraction strategy", default=None
+    )
+    
+    # TODO: update the resolved_strategy method
+    def resolved_strategy(self, root_dir: str, encoding_model: str | None) -> dict:
+        """Get the resolved entity extraction strategy."""
+        from graphrag.index.operations.extract_entities import (
+            ExtractEntityStrategyType,
+        )
+        
+        return self.strategy or {
+            "type": ExtractEntityStrategyType.graph_intelligence,
+            "llm": self.llm.model_dump(),
+            **self.parallelization.model_dump(),
+            "extraction_prompt": (Path(root_dir) / self.prompt)
+            .read_bytes()
+            .decode(encoding="utf-8")
+            if self.prompt
+            else None,
+            "max_gleanings": self.max_gleanings,
+            # It's prechunked in create_base_text_units
+            "encoding_name": encoding_model or self.encoding_model,
+            "prechunked": True,
+            "use_doc_id": self.use_doc_id,
+        }

--- a/graphrag/index/create_pipeline_config.py
+++ b/graphrag/index/create_pipeline_config.py
@@ -192,8 +192,16 @@ def _text_unit_workflows(
                         settings.encoding_model
                     )
                 },
-                "sentence_reconstruction": settings.sentence_reconstruction.sentence_reconstruction,
-                **settings.sentence_reconstruction.parallelization.model_dump(),
+                "sentence_reconstruction": {
+                    "enabled": settings.sentence_reconstruction.enabled,
+                    "strategy": settings.sentence_reconstruction.resolved_strategy(
+                        settings.root_dir
+                    ),
+                    "async_mode": settings.async_mode,
+                    **settings.sentence_reconstruction.parallelization.model_dump(),
+                }
+
+                
             },
         ),
         PipelineWorkflowReference(

--- a/graphrag/index/create_pipeline_config.py
+++ b/graphrag/index/create_pipeline_config.py
@@ -192,6 +192,8 @@ def _text_unit_workflows(
                         settings.encoding_model
                     )
                 },
+                "sentence_reconstruction": settings.sentence_reconstruction.sentence_reconstruction,
+                **settings.sentence_reconstruction.parallelization.model_dump(),
             },
         ),
         PipelineWorkflowReference(

--- a/graphrag/index/flows/reconstruct_sentence.py
+++ b/graphrag/index/flows/reconstruct_sentence.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""All the steps to transform the text units."""
+
+import logging
+
+import pandas as pd
+from datashaper import (
+    AsyncType,
+    VerbCallbacks,
+    progress_iterable,
+)
+
+from graphrag.cache.pipeline_cache import PipelineCache
+from graphrag.index.operations.reconstruct_sentence.reconstruct_sentence import run_resonstruct_sentence
+
+log = logging.getLogger(__name__)
+
+
+async def reconstruct_sentence(
+    base_text_units: pd.DataFrame | None,
+    callbacks: VerbCallbacks,
+    cache: PipelineCache,
+    strategy: dict,
+    async_mode: AsyncType = AsyncType.AsyncIO,
+    num_threads: int = 4,
+) -> None:
+    """All the steps to reconstruct sentences."""
+
+    log.info("Reconstructing sentences")
+    reconstructed_sentences = await run_resonstruct_sentence(
+        base_text_units,
+        callbacks,
+        cache,
+        strategy,
+        async_mode=async_mode,
+        num_threads=num_threads,
+    )
+
+    return reconstructed_sentences

--- a/graphrag/index/operations/reconstruct_sentence/__init__.py
+++ b/graphrag/index/operations/reconstruct_sentence/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""The Indexing Engine sentence reconstruction package root."""
+
+from graphrag.index.operations.reconstruct_sentence.reconstruct_sentence import (
+    SentenceReconstructionStrategyType,
+    run_resonstruct_sentence,
+)
+
+__all__ = ["SentenceReconstructionStrategyType", "run_resonstruct_sentence"]

--- a/graphrag/index/operations/reconstruct_sentence/plain_llm_strategy.py
+++ b/graphrag/index/operations/reconstruct_sentence/plain_llm_strategy.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""A module containing run_plain_llm, run_reconstruct_sentence and _create_text_splitter methods to run graph intelligence."""
+
+import traceback
+from datashaper import VerbCallbacks
+from fnllm import ChatLLM
+from dataclasses import asdict
+
+import graphrag.config.defaults as defs
+from graphrag.cache.pipeline_cache import PipelineCache
+from graphrag.index.llm.load_llm import load_llm, read_llm_params
+from graphrag.index.operations.reconstruct_sentence.sentence_reconstructor import SentenceReconstructor
+from graphrag.index.operations.reconstruct_sentence.typing import (
+    BaseTextUnit,
+    SentenceReconstructionResult,
+    StrategyConfig,
+)
+from graphrag.index.utils.rate_limiter import RateLimiter
+import logging
+
+log = logging.getLogger(__name__)
+
+async def run_plain_llm(
+    tunit: BaseTextUnit,
+    callbacks: VerbCallbacks,
+    cache: PipelineCache,
+    args: StrategyConfig,
+) -> SentenceReconstructionResult:
+    """Run the plain llm sentence reconstruction strategy."""
+    llm_config = read_llm_params(args.get("llm", {}))
+    llm = load_llm("sentence_reconstruction", llm_config, callbacks=callbacks, cache=cache)
+    return await run_reconstruct_sentence(llm, tunit, callbacks, args)
+
+
+async def run_reconstruct_sentence(
+    llm: ChatLLM,
+    tunit: BaseTextUnit,
+    callbacks: VerbCallbacks | None,
+    args: StrategyConfig,
+) -> SentenceReconstructionResult:
+    # RateLimiter
+    rate_limiter = RateLimiter(rate=1, per=60)
+    reconstructor = SentenceReconstructor(
+        llm,
+        reconstruction_prompt=args.get("reconstruction_prompt", None),
+        on_error=lambda e, stack, _data: callbacks.error(
+            "Sentence Reconstruction Error", e, stack
+        ),
+    )
+
+    try:
+        await rate_limiter.acquire()
+        reconstructed_sentence = await reconstructor(tunit.text)
+        result = SentenceReconstructionResult(**asdict(tunit))
+        result["text"]=reconstructed_sentence.output
+        return result
+    except Exception as e:
+        log.exception("Error processing docs: %s", tunit.id)
+        callbacks.error("Sentence Recontruction Error", e, traceback.format_exc())
+        return None

--- a/graphrag/index/operations/reconstruct_sentence/reconstruct_sentence.py
+++ b/graphrag/index/operations/reconstruct_sentence/reconstruct_sentence.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""A module containing entity_extract methods."""
+
+import logging
+from typing import Any
+
+import pandas as pd
+from datashaper import (
+    AsyncType,
+    NoopVerbCallbacks,
+    VerbCallbacks,
+    derive_from_rows,
+    progress_ticker,
+)
+
+from graphrag.cache.pipeline_cache import PipelineCache
+from graphrag.index.operations.reconstruct_sentence.typing import (
+    BaseTextUnit,
+    SentenceReconstructionStrategy,
+    SentenceReconstructionStrategyType,
+)
+
+log = logging.getLogger(__name__)
+
+
+async def run_resonstruct_sentence(
+    base_text_units: pd.DataFrame,
+    callbacks: VerbCallbacks,
+    cache: PipelineCache,
+    strategy: dict[str, Any] | None,
+    async_mode: AsyncType = AsyncType.AsyncIO,
+    num_threads: int = 4,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Recontruct sentence from a piece of text."""
+
+    tick = progress_ticker(callbacks.progress, len(base_text_units))
+    strategy_config = {**strategy}
+    runner = _load_strategy(
+        strategy.get("type", SentenceReconstructionStrategyType.plain_llm)
+    )
+
+    async def run_generate(record):
+        result = await runner(
+            tunit=BaseTextUnit(**record),
+            callbacks=callbacks,
+            cache=cache,
+            args=strategy_config,
+        )
+        tick()
+        return result
+
+    reconstructed_sentences = await derive_from_rows(
+        base_text_units,
+        run_generate,
+        callbacks=NoopVerbCallbacks(),
+        num_threads=num_threads,
+        scheduling_type=async_mode,
+    )
+    reconstructed_sentences = [item for item in reconstructed_sentences if item is not None]
+
+    return pd.DataFrame(reconstructed_sentences)
+
+
+def _load_strategy(strategy_type: SentenceReconstructionStrategyType) -> SentenceReconstructionStrategy:
+    """Load strategy method definition."""
+    match strategy_type:
+        case SentenceReconstructionStrategyType.plain_llm:
+            from graphrag.index.operations.reconstruct_sentence.plain_llm_strategy import (
+                run_plain_llm,
+            )
+
+            return run_plain_llm
+        
+        case _:
+            msg = f"Unknown strategy: {strategy_type}"
+            raise ValueError(msg)

--- a/graphrag/index/operations/reconstruct_sentence/sentence_reconstructor/__init__.py
+++ b/graphrag/index/operations/reconstruct_sentence/sentence_reconstructor/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""The Indexing Engine community reports package root."""
+
+from graphrag.index.operations.reconstruct_sentence.sentence_reconstructor.sentence_reconstructor import (
+    SentenceReconstructor
+)
+
+__all__ = [
+    "SentenceReconstructor",
+]

--- a/graphrag/index/operations/reconstruct_sentence/sentence_reconstructor/sentence_reconstructor.py
+++ b/graphrag/index/operations/reconstruct_sentence/sentence_reconstructor/sentence_reconstructor.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""A module containing 'CommunityReportsResult' and 'CommunityReportsExtractor' models."""
+
+import logging
+import traceback
+from dataclasses import dataclass
+from typing import Any
+
+from fnllm import ChatLLM
+from pydantic import BaseModel, Field
+
+from graphrag.index.typing import ErrorHandlerFn
+from graphrag.prompts.index.sentence_reconstruction import RECONSTRUCT_SENTENCE_PROMPT
+
+log = logging.getLogger(__name__)
+
+
+class SentenceReconstructionResponse(BaseModel):
+    """A model for the expected LLM response shape."""
+
+    output: str = Field(description="Reconstructed sentence.")
+
+
+@dataclass
+class SentenceReconstructorResult:
+    """Core concept reports result class definition."""
+
+    output: str | None
+
+
+class SentenceReconstructor:
+    """Core concept reports extractor class definition."""
+
+    _llm: ChatLLM
+    _input_text_key: str
+    _reconstruction_prompt: str
+    _on_error: ErrorHandlerFn
+    max_token: int | None
+
+    def __init__(
+        self,
+        llm_invoker: ChatLLM,
+        input_text_key: str | None = None,
+        reconstruction_prompt: str | None = None,
+        on_error: ErrorHandlerFn | None = None,
+        max_token: int = None
+    ):
+        """Init method definition."""
+        self._llm = llm_invoker
+        self._input_text_key = input_text_key or "input_text"
+        self._reconstruction_prompt = reconstruction_prompt or RECONSTRUCT_SENTENCE_PROMPT
+        self._on_error = on_error or (lambda _e, _s, _d: None)
+        self._max_token = max_token or 1500
+
+    async def __call__(self, text: str):
+        """Call method definition."""
+        output = None
+        try:
+            prompt = self._reconstruction_prompt.format(**{
+                self._input_text_key: text
+            })
+            response = await self._llm(
+                prompt,
+                json=True,
+                name="sentence_reconstruction",
+                json_model=SentenceReconstructionResponse,
+                model_parameters={"max_tokens": self._max_token},
+            )
+            output = response.parsed_json
+        except Exception as e:
+            log.exception("error reconstructing sentence")
+            self._on_error(e, traceback.format_exc(), None)
+
+        return SentenceReconstructorResult(
+            output=output.output ,
+        )

--- a/graphrag/index/operations/reconstruct_sentence/typing.py
+++ b/graphrag/index/operations/reconstruct_sentence/typing.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""A module containing 'Document' and 'EntityExtractionResult' models."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, TypedDict
+
+from datashaper import VerbCallbacks
+
+from graphrag.cache.pipeline_cache import PipelineCache
+
+StrategyConfig = dict[str, Any]
+
+@dataclass
+class BaseTextUnit:
+    """Document class definition."""
+
+    id: str
+    text: str
+    document_ids: list[str]
+    n_tokens: int
+
+class SentenceReconstructionResult(TypedDict):
+    """Sentence reconstruction result class definition."""
+
+    id: str
+    text: str
+    document_ids: list[str]
+    n_tokens: int
+
+
+SentenceReconstructionStrategy = Callable[
+    [
+        BaseTextUnit,
+        VerbCallbacks,
+        PipelineCache,
+        StrategyConfig,
+    ],
+    Awaitable[SentenceReconstructionResult],
+]
+
+
+class SentenceReconstructionStrategyType(str, Enum):
+    """SentenceReconstructionStrategyType class definition."""
+
+    plain_llm = "plain_llm"
+
+    def __repr__(self):
+        """Get a string representation."""
+        return f'"{self.value}"'

--- a/graphrag/index/workflows/v1/create_base_text_units.py
+++ b/graphrag/index/workflows/v1/create_base_text_units.py
@@ -3,11 +3,14 @@
 
 """A module containing build_steps method definition."""
 
+import logging
+
 from typing import Any, cast
 
 import pandas as pd
 from datashaper import (
     DEFAULT_INPUT_NAME,
+    AsyncType,
     Table,
     VerbCallbacks,
     VerbInput,
@@ -15,15 +18,18 @@ from datashaper import (
 )
 from datashaper.table_store.types import VerbResult, create_verb_result
 
+from graphrag.cache.pipeline_cache import PipelineCache
 from graphrag.index.config.workflow import PipelineWorkflowConfig, PipelineWorkflowStep
 from graphrag.index.flows.create_base_text_units import (
     create_base_text_units,
 )
+from graphrag.index.flows.reconstruct_sentence import reconstruct_sentence
 from graphrag.index.operations.snapshot import snapshot
 from graphrag.storage.pipeline_storage import PipelineStorage
 
 workflow_name = "create_base_text_units"
 
+log = logging.getLogger(__name__)
 
 def build_steps(
     config: PipelineWorkflowConfig,
@@ -37,8 +43,14 @@ def build_steps(
     chunk_by_columns = config.get("chunk_by", []) or []
     text_chunk_config = config.get("text_chunk", {})
     chunk_strategy = text_chunk_config.get("strategy")
-
     snapshot_transient = config.get("snapshot_transient", False) or False
+
+    sentence_reconstruction_config = config.get("sentence_reconstruction", {})
+    reconstruction_enabled = sentence_reconstruction_config.get("enabled", False)
+    reconstruction_strategy = sentence_reconstruction_config.get("strategy", {})
+    reconstruction_async_mode = sentence_reconstruction_config.get("async_mode")
+    reconstruction_num_threads = sentence_reconstruction_config.get("num_threads")
+
     return [
         {
             "verb": workflow_name,
@@ -46,6 +58,10 @@ def build_steps(
                 "chunk_by_columns": chunk_by_columns,
                 "chunk_strategy": chunk_strategy,
                 "snapshot_transient_enabled": snapshot_transient,
+                "reconstruction_enabled": reconstruction_enabled,
+                "reconstruction_strategy": reconstruction_strategy,
+                "reconstruction_async_mode": reconstruction_async_mode,
+                "reconstruction_num_threads": reconstruction_num_threads
             },
             "input": {"source": DEFAULT_INPUT_NAME},
         },
@@ -56,11 +72,16 @@ def build_steps(
 async def workflow(
     input: VerbInput,
     callbacks: VerbCallbacks,
+    cache: PipelineCache,
     storage: PipelineStorage,
     runtime_storage: PipelineStorage,
     chunk_by_columns: list[str],
     chunk_strategy: dict[str, Any] | None = None,
     snapshot_transient_enabled: bool = False,
+    reconstruction_enabled: bool = False,
+    reconstruction_strategy: dict[str, Any] | None = None,
+    reconstruction_async_mode: AsyncType = AsyncType.AsyncIO,
+    reconstruction_num_threads: int = 4,
     **_kwargs: dict,
 ) -> VerbResult:
     """All the steps to transform base text_units."""
@@ -72,6 +93,17 @@ async def workflow(
         chunk_by_columns,
         chunk_strategy=chunk_strategy,
     )
+
+    if reconstruction_enabled:
+        log.info("Sentence reconstruction is enabled")
+        output = await reconstruct_sentence(
+            output,
+            callbacks,
+            cache,
+            reconstruction_strategy,
+            reconstruction_async_mode,
+            reconstruction_num_threads,
+        )
 
     await runtime_storage.set("base_text_units", output)
 

--- a/graphrag/prompts/index/sentence_reconstruction.py
+++ b/graphrag/prompts/index/sentence_reconstruction.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+"""A file containing prompts definition."""
+
+RECONSTRUCT_SENTENCE_PROMPT = """
+Task: Transform Sentence Structures for Referenced Papers and the Current Paper
+
+Context:  
+You are given a passage containing references to prior research papers (shown as [numbers]) and references to the current paper (e.g., “our paper,” “we,” or “this study”). Your goal is to restructure each relevant sentence to make these references the subjects where it makes logical sense, but without forcing unnatural constructions.
+
+Entities to Modify  
+1. Referenced Papers  
+   - Any citation in the form [X] (e.g., [14], [7]) refers to a previous study.  
+   - Where it fits naturally, transform the citation into the subject of the sentence by replacing “[X]” with TOKEN_bX.  
+   - Do not rewrite the sentence in an awkward way just to make the citation a subject.
+
+2. Current Paper  
+   - Any phrase referring to the present paper (e.g., “our paper,” “we,” “this study”) is replaced with TOKEN_b0.  
+   - Treat TOKEN_b0 as a possible subject in the sentence if it flows logically.
+
+Return output as a well-formed JSON-formatted string with the following format:
+
+{{
+    "output": "<reconstructed_sentence>",
+}}
+
+---
+
+Transformation Rules  
+
+1. Natural Incorporation of Referenced Papers  
+   - Preserve the original meaning while transforming sentences so that references become natural subjects wherever possible.  
+   - Avoid forcing citations to the front of the sentence if it creates awkward phrasing. Use verbs like “stated that,” “proposed,” “introduced,” or “demonstrated that” to connect citations properly.
+
+2. Current Paper as a Subject  
+   - Replace the original references to the current paper with TOKEN_b0.  
+   - If it naturally makes sense for TOKEN_b0 to be the subject, reorganize the sentence accordingly.
+
+3. Multiple References  
+   - If a sentence cites more than one paper, combine them appropriately as joint subjects (e.g., “TOKEN_b3 and TOKEN_b7 stated that...”) or separate them if that’s clearer.
+
+4. Logical Consistency  
+   - Keep the sentence’s original intention and context intact. If restructuring creates confusion or awkwardness, leave the citation where it is.
+
+5. Valid Citation Numbers Only  
+   - Only use TOKEN_bX for citations that explicitly appear in the text.  
+   - Do not introduce or modify citation numbers beyond what is given.
+
+6. Preserve Sentence Count and Order  
+   - If the original passage has N sentences, your output must also have N sentences in the same order.  
+   - For each sentence in the input, either transform it (if needed) or leave it unchanged, but do not merge or split sentences.  
+   - This ensures the output’s sentence count and sequence remain identical to the input.
+
+-Examples-
+######################
+Example 1:
+
+Original:
+<h1>abstract</h1> <p>Candidate retrieval is the first stage in recommendation systems, where a light-weight system is used to retrieve potentially relevant items for an input user
+ These candidate items are then ranked and pruned in later stages of recommender systems using a more complex ranking model
+ As the top of the recommendation funnel, it is important to retrieve a high-recall candidate set to feed into downstream ranking models
+ A common approach is to leverage approximate nearest neighbor (ANN) search from a single dense query embedding; however, this approach this can yield a low-diversity result set with many near duplicates
+ As users often have multiple interests, candidate retrieval should ideally return a diverse set of candidates reflective of the user's multiple interests
+ To this end, we introduce kNN-Embed, a general approach to improving diversity in dense ANN-based retrieval
+ kNN-Embed represents each user as a smoothed mixture over learned item clusters that represent distinct "interests" of the user
+ By querying each of a user's mixture component in proportion to their mixture weights, we retrieve a high-diversity set of candidates reflecting elements from each of a user's interests
+ We experimentally compare kNN-Embed to standard ANN candidate retrieval, and show significant improvements in overall recall and improved diversity across three datasets
+ Accompanying this work, we open source a large Twitter follow-graph dataset1, to spur further research in graph-mining and representation learning for recommender systems
+------------------------
+output:
+{{
+   "output": "<h1>abstract</h1> <p> Candidate retrieval is the first stage in recommendation systems, where a light‐weight system is used to retrieve potentially relevant items for an input user. These candidate items are then ranked and pruned in later stages of recommender systems using a more complex ranking model. As the top of the recommendation funnel, it is important to retrieve a high‐recall candidate set to feed into downstream ranking models. A common approach is to leverage approximate nearest neighbor (ANN) search from a single dense query embedding; however, this approach can yield a low‐diversity result set with many near duplicates. As users often have multiple interests, candidate retrieval should ideally return a diverse set of candidates reflective of the user's multiple interests. To this end, TOKEN_b0 introduce kNN-Embed, a general approach to improving diversity in dense ANN-based retrieval. kNN-Embed represents each user as a smoothed mixture over learned item clusters that represent distinct "interests" of the user. By querying each of a user's mixture component in proportion to their mixture weights, TOKEN_b0 retrieve a high-diversity set of candidates reflecting elements from each of a user's interests. TOKEN_b0 experimentally compare kNN-Embed to standard ANN candidate retrieval, and show significant improvements in overall recall and improved diversity across three datasets. Accompanying this work, TOKEN_b0 open source a large Twitter follow-graph dataset1, to spur further research in graph-mining and representation learning for recommender systems."
+}}
+######################
+Example 2:
+
+Original:
+<p>Introduction </p><h2>text</h2> <p>Recommendation systems for online services such as e-commerce or social networks present users with suggestions in the form of ranked lists of items [5]
+ </p><h2>publication_ref</h2> <p>['b4'] </p><h2>figure_ref</h2> <p>[] </p><h2>table_ref</h2> <p>[] </p><h2>heading</h2> <p>Related Works </p><h2>text</h2> <p>Traditionally, techniques for candidate retrieval rely on fast, scalable approaches to search large collections for similar sparse vectors [3,1]
+ Approaches apply indexing and optimization strategies to scale sparse similarity search
+ One such strategy builds a static clustering of the entire collection of items; clusters are retrieved based on how well their centroids match the query [25,20]
+ These methods either (1) match the query against clusters of items and rank clusters based on similarity to query or (2) utilize clusters as a form of item smoothing
+------------------------
+output:
+{{
+   "output": "<p>Introduction</p> <h2>text</h2> <p> TOKEN_b5 showed that recommendation systems for online services such as e-commerce or social networks present users with suggestions in the form of ranked lists of items. </p> <h2>publication_ref</h2> <p>['b4']</p> <h2>figure_ref</h2> <p>[]</p> <h2>table_ref</h2> <p>[]</p> <h2>heading</h2> <p>Related Works</p> <h2>text</h2> <p> TOKEN_b3 and TOKEN_b1 demonstrated that techniques for candidate retrieval rely on fast, scalable approaches to search large collections for similar sparse vectors. Approaches apply indexing and optimization strategies to scale sparse similarity search. TOKEN_b25 and TOKEN_b20 proposed a strategy that builds a static clustering of the entire collection of items, retrieving clusters based on how well their centroids match the query. These methods either (1) match the query against clusters of items and rank clusters based on similarity to query or (2) utilize clusters as a form of item smoothing"
+}}
+######################
+Example 3:
+
+Original:
+For embedding-based recommender systems [28], large-scale dense similarity search has been applied for retrieval
+ Some approaches proposed utilize hashing-based techniques such as mapping input and targets to discrete partitions and selecting targets from the same partitions as inputs [26]
+ With the advent of fast approximate nearest-neighbor search [21,13], dense nearest neighbor has been applied by recommender systems for candidate retrieval
+------------------------
+output:
+{{
+   "output": "TOKEN_b28 demonstrated that for embedding-based recommender systems, large-scale dense similarity search has been applied for retrieval. TOKEN_b26 proposed utilizing hashing-based techniques such as mapping input and targets to discrete partitions and selecting targets from the same partitions as inputs. TOKEN_b21 and TOKEN_b13 demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval"
+}}
+
+######################
+Example 4:
+
+Original:
+When utilizing graph-based embeddings for recommender systems [8], some methods transform single-mode embeddings to multiple modes by clustering user actions.
+ Our method extends upon this idea by incorporating nearest neighbor smoothing to address the sparsity problem of generating mixtures of embeddings for users with few engagements
+------------------------
+output:
+{{
+   "output": "When utilizing graph-based embeddings for recommender systems, TOKEN_b8 demonstrated that some methods transform single-mode embeddings to multiple modes by clustering user actions. TOKEN_b0 extends upon this idea by incorporating nearest neighbor smoothing to address the sparsity problem of generating mixtures of embeddings for users with few engagements."
+}}
+
+######################
+Example 5:
+
+Original:
+Smoothing via k-nearest-neighbor search has been applied for better language modeling [16] and machine translation [15]
+ We smooth low-engagement user representations by leveraging engagements from similar users
+------------------------
+output:
+TOKEN_b16 and TOKEN_b15 demonstrated that smoothing via k-nearest-neighbor search has been applied for better language modeling and machine translation. TOKEN_b0 smooth low-engagement user representations by leveraging engagements from similar users.
+
+-Real Data-
+######################
+
+Use the following text for your answer. Do not make anything up in your answer.
+
+Original: {input_text}
+
+Return output as a well-formed JSON-formatted string with the following format:
+
+{{
+    "output": "<reconstructed_sentence>",
+}}
+
+######################
+output: """

--- a/onepiece_rag/prompts/entity_extraction_with_reconstructed_sentence.txt
+++ b/onepiece_rag/prompts/entity_extraction_with_reconstructed_sentence.txt
@@ -1,0 +1,364 @@
+-Goal-  
+Given a text document that is potentially relevant to this activity and a list of entity types, identify all entities of those types from the text and all relationships among the identified entities.
+
+-Steps-
+
+Identify all entities. For each identified entity, extract the following information:
+
+entity_type: One of the following types: [RESEARCH PAPER, CONCEPT, ORGANIZATION]
+
+entity_name: The specific name of the entity.
+
+When x is an integer, any instance of the form TOKEN_bx is considered a RESEARCH PAPER entity. This entity must be formatted exactly as [doc_id:bx], where doc_id is the provided document identifier and x is the number within the square brackets (e.g., TOKEN_b28 becomes [1:b28] for doc_id=1, and TOKEN_b15 becomes [3:b15] for doc_id=3).  
+This naming rule for research papers is critical and must be followed without exception to ensure consistency and accuracy. Do not deviate from this rule under any circumstances.
+
+If the entity_type is 'CONCEPT' or 'ORGANIZATION' use the name as it appears in the text.
+
+entity_description: Comprehensive description of the entity's attributes and activities  
+Format each entity as ("entity"{tuple_delimiter}<entity_name>{tuple_delimiter}<entity_type>{tuple_delimiter}<entity_description>)
+
+From the entities identified in step 1, identify all pairs of (source_entity, target_entity) that are clearly related to each other.  
+For each pair of related entities, extract the following information:
+
+source_entity: name of the source entity, as identified in step 1
+
+target_entity: name of the target entity, as identified in step 1
+
+relationship_description: explanation as to why you think the source entity and the target entity are related to each other
+
+relationship_strength: an integer score between 1 to 10, indicating strength of the relationship between the source entity and target entity  
+Format each relationship as ("relationship"{tuple_delimiter}<source_entity>{tuple_delimiter}<target_entity>{tuple_delimiter}<relationship_description>{tuple_delimiter}<relationship_strength>)
+
+Return output in English as a single list of all the entities and relationships identified in steps 1 and 2. Use 
+{record_delimiter} as the list delimiter.
+
+If you have to translate into English, just translate the descriptions, nothing else!
+
+When finished, output {completion_delimiter}.
+
+#############################
+
+Example 1:
+
+entity_types: [RESEARCH PAPER, CONCEPT, ORGANIZATION]
+doc_id: 18
+text: TOKEN_b28 demonstrated that for embedding-based recommender systems, large-scale dense similarity search has been applied for retrieval.
+TOKEN_b26 proposed utilizing hashing-based techniques such as mapping input and targets to discrete partitions and selecting targets from the same partitions as inputs.
+TOKEN_b21, TOKEN_b13, and TOKEN_b5 demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval.
+
+------------------------
+output:
+(“entity”<tuple_delimiter>[18:b28]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated that for embedding-based recommender systems, large-scale dense similarity search has been applied for retrieval) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[18:b26]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed utilizing hashing-based techniques by mapping inputs and targets to discrete partitions) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[18:b21]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[18:b13]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[18:b5]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval) 
+{record_delimiter}
+(“entity”<tuple_delimiter>embedding-based recommender systems<tuple_delimiter>CONCEPT<tuple_delimiter>A concept describing recommender systems that utilize embedding techniques to generate recommendations) 
+{record_delimiter}
+(“entity”<tuple_delimiter>large-scale dense similarity search<tuple_delimiter>CONCEPT<tuple_delimiter>A concept involving the use of dense similarity measures on a large scale for retrieval in recommender systems) 
+{record_delimiter}
+(“entity”<tuple_delimiter>hashing-based techniques<tuple_delimiter>CONCEPT<tuple_delimiter>A concept involving the use of hashing to map inputs and targets into discrete partitions for efficient retrieval) 
+{record_delimiter}
+(“entity”<tuple_delimiter>discrete partitions<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to segregated groups used in hashing-based techniques to cluster inputs and targets) 
+{record_delimiter}
+(“entity”<tuple_delimiter>fast approximate nearest-neighbor search<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to rapid methods for approximating nearest neighbor search in high-dimensional spaces) 
+{record_delimiter}
+(“entity”<tuple_delimiter>recommender systems<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to systems that provide suggestions based on user data) 
+{record_delimiter}
+(“entity”<tuple_delimiter>dense nearest neighbor<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the application of dense vector representations for nearest neighbor search in candidate retrieval) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b28]<tuple_delimiter>embedding-based recommender systems<tuple_delimiter>“demonstrated the application of large-scale dense similarity search within embedding-based recommender systems”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b28]<tuple_delimiter>large-scale dense similarity search<tuple_delimiter>“demonstrated the use of large-scale dense similarity search for retrieval”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b26]<tuple_delimiter>hashing-based techniques<tuple_delimiter>“proposed the utilization of hashing-based techniques for mapping inputs and targets”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b26]<tuple_delimiter>discrete partitions<tuple_delimiter>“proposed selecting targets from the same discrete partitions as inputs”<tuple_delimiter>7) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b21]<tuple_delimiter>fast approximate nearest-neighbor search<tuple_delimiter>“demonstrated the use of fast approximate nearest-neighbor search in candidate retrieval”<tuple_delimiter>9) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b21]<tuple_delimiter>dense nearest neighbor<tuple_delimiter>“demonstrated the application of dense nearest neighbor for candidate retrieval”<tuple_delimiter>9) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b13]<tuple_delimiter>fast approximate nearest-neighbor search<tuple_delimiter>“demonstrated the use of fast approximate nearest-neighbor search in candidate retrieval”<tuple_delimiter>9) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b13]<tuple_delimiter>dense nearest neighbor<tuple_delimiter>“demonstrated the application of dense nearest neighbor for candidate retrieval”<tuple_delimiter>9) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b5]<tuple_delimiter>fast approximate nearest-neighbor search<tuple_delimiter>“demonstrated the use of fast approximate nearest-neighbor search in candidate retrieval”<tuple_delimiter>9) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b5]<tuple_delimiter>dense nearest neighbor<tuple_delimiter>“demonstrated the application of dense nearest neighbor for candidate retrieval”<tuple_delimiter>9) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b21]<tuple_delimiter>recommender systems<tuple_delimiter>“demonstrated that recommender systems applied dense nearest neighbor for candidate retrieval”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b13]<tuple_delimiter>recommender systems<tuple_delimiter>“demonstrated that recommender systems applied dense nearest neighbor for candidate retrieval”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[18:b5]<tuple_delimiter>recommender systems<tuple_delimiter>“demonstrated that recommender systems applied dense nearest neighbor for candidate retrieval”<tuple_delimiter>8)
+{completion_delimiter}
+
+#############################
+
+Example 2:
+
+entity_types: [RESEARCH PAPER, CONCEPT, ORGANIZATION]
+doc_id: 3
+text: TOKEN_b4 demonstrated that smart transportation and traffic management are highly needed as they broadly influence almost every aspect of smart city operations on a daily basis.
+TOKEN_b4 and TOKEN_b5 highlighted that trip route planning receives significant interest, particularly in large and crowded cities.
+TOKEN_b6 proposed that trip planning applications and service providers offer route recommendations based on relatively shorter paths, traffic congestion, and even up-to-date construction works.
+Consequently, some of the key players in route planning, such as Google, have adopted online dynamic routing driven by live traffic network information.
+For example, Google Maps provides online suggestions for vehicle re-routing when roads experience instantaneous traffic congestion based on various factors such as untraditional mobility behavior or accidents.
+On the other hand, the crowdsensed-based trip planning application Waze, as demonstrated by TOKEN_b7, relies on lively sensed traffic situations that are shared with users’ intervention.
+TOKEN_b8 introduced the APOLO system to overcome the network overload present in many traffic management systems due to information exchange between vehicles and servers.
+This system proposed a centralized traffic monitoring approach that operates both online and offline.
+In the offline stage, mobility patterns are derived through historical data processing, while in the online stage, vehicles are re-routed away from congested routes.
+The results showed a 17% reduction in travel time along with a 6% speed increase compared to existing approaches.
+Additionally, various efforts in the literature have suggested methods to enable shorter and faster routing for land vehicles.
+TOKEN_b9 introduced an adaptive routing approach that treated route planning as a probabilistic dynamic problem.
+Their algorithms aimed to reduce the predicted en route trip time while considering broadcasted traffic information, onboard-based traffic state measurements, and historical traffic patterns.
+------------------------
+output:
+(“entity”<tuple_delimiter>[3:b4]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated the need for smart transportation and traffic management in smart city operations) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[3:b5]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that highlighted significant interest in trip route planning in large and crowded cities) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[3:b6]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed route recommendations based on shorter paths, traffic congestion, and construction works) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[3:b7]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper demonstrating that Waze relies on real-time traffic sensing with user intervention) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[3:b8]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced the APOLO system employing a centralized traffic monitoring approach to reduce travel time and increase speed) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[3:b9]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced an adaptive routing approach treating route planning as a probabilistic dynamic problem to reduce en route trip time) 
+{record_delimiter}
+(“entity”<tuple_delimiter>smart transportation<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the use of innovative technologies to improve transportation systems in smart cities) 
+{record_delimiter}
+(“entity”<tuple_delimiter>traffic management<tuple_delimiter>CONCEPT<tuple_delimiter>A concept involving planning, monitoring, and controlling traffic to optimize road usage and safety) 
+{record_delimiter}
+(“entity”<tuple_delimiter>trip route planning<tuple_delimiter>CONCEPT<tuple_delimiter>A concept related to planning efficient travel routes, especially in crowded urban areas) 
+{record_delimiter}
+(“entity”<tuple_delimiter>route recommendations<tuple_delimiter>CONCEPT<tuple_delimiter>A concept where systems suggest optimal travel routes based on factors like distance, congestion, and construction) 
+{record_delimiter}
+(“entity”<tuple_delimiter>online dynamic routing<tuple_delimiter>CONCEPT<tuple_delimiter>A concept where routing decisions are updated in real time based on live traffic information) 
+{record_delimiter}
+(“entity”<tuple_delimiter>centralized traffic monitoring approach<tuple_delimiter>CONCEPT<tuple_delimiter>A concept involving a centralized system to monitor and manage traffic conditions both online and offline) 
+{record_delimiter}
+(“entity”<tuple_delimiter>adaptive routing approach<tuple_delimiter>CONCEPT<tuple_delimiter>A concept that treats route planning as a probabilistic dynamic problem to minimize travel time) 
+{record_delimiter}
+(“entity”<tuple_delimiter>Google<tuple_delimiter>ORGANIZATION<tuple_delimiter>A global technology company involved in route planning and online mapping services) 
+{record_delimiter}
+(“entity”<tuple_delimiter>Google Maps<tuple_delimiter>ORGANIZATION<tuple_delimiter>An online mapping service provided by Google offering live traffic data and route suggestions) 
+{record_delimiter}
+(“entity”<tuple_delimiter>Waze<tuple_delimiter>ORGANIZATION<tuple_delimiter>A crowdsensed-based trip planning application that relies on real-time traffic data shared by users) 
+{record_delimiter}
+(“entity”<tuple_delimiter>APOLO system<tuple_delimiter>CONCEPT<tuple_delimiter>A system designed to overcome network overload in traffic management by employing a centralized monitoring approach) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[3:b4]<tuple_delimiter>smart transportation<tuple_delimiter>“demonstrated the need for smart transportation in smart city operations”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[3:b4]<tuple_delimiter>traffic management<tuple_delimiter>“demonstrated the critical role of traffic management in daily smart city operations”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[3:b5]<tuple_delimiter>trip route planning<tuple_delimiter>“highlighted the significance of trip route planning in large and crowded cities”<tuple_delimiter>7) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[3:b6]<tuple_delimiter>route recommendations<tuple_delimiter>“proposed route recommendations based on shorter paths and traffic conditions”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>Google Maps<tuple_delimiter>online dynamic routing<tuple_delimiter>“demonstrates online dynamic routing by providing vehicle re-routing suggestions based on live traffic data”<tuple_delimiter>9) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[3:b7]<tuple_delimiter>Waze<tuple_delimiter>“demonstrated that Waze relies on real-time traffic sensing and user intervention”<tuple_delimiter>7) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[3:b8]<tuple_delimiter>APOLO system<tuple_delimiter>“introduced the APOLO system to mitigate network overload in traffic management systems”<tuple_delimiter>9) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[3:b8]<tuple_delimiter>centralized traffic monitoring approach<tuple_delimiter>“proposed a centralized approach to monitor traffic both online and offline”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[3:b9]<tuple_delimiter>adaptive routing approach<tuple_delimiter>“introduced an adaptive routing approach treating route planning as a probabilistic dynamic problem”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>Google<tuple_delimiter>Google Maps<tuple_delimiter>“Google Maps is a service provided by Google, integrating live traffic data for route planning”<tuple_delimiter>10) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>trip route planning<tuple_delimiter>route recommendations<tuple_delimiter>“route recommendations are integral to effective trip route planning”<tuple_delimiter>7)
+{completion_delimiter}
+
+
+#############################
+
+Example 3:
+
+entity_types: [RESEARCH PAPER, CONCEPT, ORGANIZATION]
+doc_id: 371
+text: TOKEN_b16, TOKEN_b17, TOKEN_b18, and TOKEN_b19 demonstrated advancements in code summarization by developing techniques for generating code comments.
+TOKEN_b20, TOKEN_b21, and TOKEN_b22 introduced methods for generating commit messages, while TOKEN_b23 and TOKEN_b24 contributed to the generation of code reviews.
+TOKEN_b25 and TOKEN_b26 proposed techniques for creating release notes.
+TOKEN_b27 and TOKEN_b28 investigated technical debt, including methods for detecting code comment inconsistencies, while TOKEN_b29 and TOKEN_b30 examined self-admitted technical debt to facilitate software maintenance.
+TOKEN_b31 introduced a technique for augmenting API documentation content by incorporating information from Stack Overflow.
+TOKEN_b32 extracted development tasks from software documents to bridge the gap between software documentation and developers’ information needs.
+TOKEN_b33 mined README files from GitHub and applied transfer learning to simplify complex documentation sentences.
+TOKEN_b34 proposed a paradigm shift in automatic documentation generation based on developers’ queries within their contexts.
+TOKEN_b0 conducted a qualitative analysis of installation-related documentation update behaviors to gain a deeper understanding and provide motivation for developing automated software tools for documentation writing.
+TOKEN_b35 highlighted that installation procedures vary in complexity, ranging from fetching a remote binary file to verifying system requirements, resolving dependencies, and ensuring component integrity.
+TOKEN_b3 and TOKEN_b36 identified documentation problems and development environment configuration as significant barriers for newcomers contributing to Open Source Software (OSS) repositories.
+TOKEN_b37 found that participation in OSS courses enhances student self-efficacy while also increasing their perception of documentation challenges, particularly regarding development environment setup.
+TOKEN_b1 emphasized that the primary content category of README files is “How,” covering instructions from environment setup to installation and project execution, reinforcing their essential role in guiding newcomers and software users.
+In contrast to previous studies focusing on the human perspective of OSS barriers for newcomers, TOKEN_b0 synthesized empirical evidence on software documentation activities related to installation by analyzing a large-scale dataset.
+This empirical evidence will contribute to mitigating documentation-related barriers for newcomers engaging with OSS projects.
+------------------------
+output:
+(“entity”<tuple_delimiter>[371:b16]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated advancements in code summarization by developing techniques for generating code comments) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b17]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated advancements in code summarization by developing techniques for generating code comments) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b18]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated advancements in code summarization by developing techniques for generating code comments) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b19]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated advancements in code summarization by developing techniques for generating code comments) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b20]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced methods for generating commit messages) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b21]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced methods for generating commit messages) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b22]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced methods for generating commit messages) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b23]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that contributed to the generation of code reviews) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b24]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that contributed to the generation of code reviews) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b25]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed techniques for creating release notes) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b26]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed techniques for creating release notes) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b27]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that investigated technical debt, including methods for detecting code comment inconsistencies) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b28]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that investigated technical debt, including methods for detecting code comment inconsistencies) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b29]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that examined self-admitted technical debt to facilitate software maintenance) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b30]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that examined self-admitted technical debt to facilitate software maintenance) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b31]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced a technique for augmenting API documentation content by incorporating information from Stack Overflow) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b32]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that extracted development tasks from software documents to bridge the gap between software documentation and developers’ information needs) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b33]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that mined README files from GitHub and applied transfer learning to simplify complex documentation sentences) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b34]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed a paradigm shift in automatic documentation generation based on developers’ queries within their contexts) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b0]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that conducted a qualitative analysis of installation-related documentation update behaviors to gain a deeper understanding and motivate automated software tool development for documentation writing) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b35]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that highlighted the varying complexity of installation procedures, from fetching remote binaries to verifying system requirements and resolving dependencies) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b3]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that identified documentation problems and development environment configuration as significant barriers for newcomers contributing to OSS repositories) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b36]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that identified documentation problems and development environment configuration as significant barriers for newcomers contributing to OSS repositories) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b37]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that found participation in OSS courses enhances student self-efficacy while increasing perception of documentation challenges, particularly in development environment setup) 
+{record_delimiter}
+(“entity”<tuple_delimiter>[371:b1]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that emphasized the primary role of README files in providing “How” instructions from environment setup to project execution for newcomers and software users) 
+{record_delimiter}
+(“entity”<tuple_delimiter>code summarization<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the automated process of summarizing code by generating descriptive comments) 
+{record_delimiter}
+(“entity”<tuple_delimiter>commit messages<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to messages that describe changes in version control commits) 
+{record_delimiter}
+(“entity”<tuple_delimiter>code reviews<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the evaluation of code by peers to improve quality) 
+{record_delimiter}
+(“entity”<tuple_delimiter>release notes<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to documentation detailing new features and changes in software releases) 
+{record_delimiter}
+(“entity”<tuple_delimiter>technical debt<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the implied cost of rework due to suboptimal design or implementation choices) 
+{record_delimiter}
+(“entity”<tuple_delimiter>self-admitted technical debt<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to technical debt explicitly acknowledged by developers through comments or documentation) 
+{record_delimiter}
+(“entity”<tuple_delimiter>API documentation<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to documentation that provides details about an application’s programming interface) 
+{record_delimiter}
+(“entity”<tuple_delimiter>development tasks<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to assignments and activities extracted from software documents) 
+{record_delimiter}
+(“entity”<tuple_delimiter>software documentation<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the process and content involved in documenting software projects) 
+{record_delimiter}
+(“entity”<tuple_delimiter>README files<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to introductory documentation files that provide instructions and information about a software project) 
+{record_delimiter}
+(“entity”<tuple_delimiter>automatic documentation generation<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the automated creation of documentation based on developer inputs or queries) 
+{record_delimiter}
+(“entity”<tuple_delimiter>installation-related documentation update behaviors<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the analysis of changes in documentation associated with software installation processes) 
+{record_delimiter}
+(“entity”<tuple_delimiter>installation procedures<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the set of steps required to install software, including dependency resolution and system requirement verification) 
+{record_delimiter}
+(“entity”<tuple_delimiter>documentation problems<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to issues or shortcomings in software documentation) 
+{record_delimiter}
+(“entity”<tuple_delimiter>development environment configuration<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the setup and arrangement of tools and settings required for software development) 
+{record_delimiter}
+(“entity”<tuple_delimiter>OSS repositories<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to repositories that host open source software projects) 
+{record_delimiter}
+(“entity”<tuple_delimiter>OSS courses<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to educational courses related to open source software) 
+{record_delimiter}
+(“entity”<tuple_delimiter>Stack Overflow<tuple_delimiter>ORGANIZATION<tuple_delimiter>An online platform and community where developers ask and answer programming questions) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b16]<tuple_delimiter>code summarization<tuple_delimiter>“demonstrated advancements in code summarization by generating techniques for code comments”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b17]<tuple_delimiter>code summarization<tuple_delimiter>“demonstrated advancements in code summarization by generating techniques for code comments”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b18]<tuple_delimiter>code summarization<tuple_delimiter>“demonstrated advancements in code summarization by generating techniques for code comments”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b19]<tuple_delimiter>code summarization<tuple_delimiter>“demonstrated advancements in code summarization by generating techniques for code comments”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b20]<tuple_delimiter>commit messages<tuple_delimiter>“introduced methods for generating commit messages”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b21]<tuple_delimiter>commit messages<tuple_delimiter>“introduced methods for generating commit messages”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b22]<tuple_delimiter>commit messages<tuple_delimiter>“introduced methods for generating commit messages”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b23]<tuple_delimiter>code reviews<tuple_delimiter>“contributed to the generation of code reviews”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b24]<tuple_delimiter>code reviews<tuple_delimiter>“contributed to the generation of code reviews”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b25]<tuple_delimiter>release notes<tuple_delimiter>“proposed techniques for creating release notes”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b26]<tuple_delimiter>release notes<tuple_delimiter>“proposed techniques for creating release notes”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b27]<tuple_delimiter>technical debt<tuple_delimiter>“investigated technical debt, including methods for detecting code comment inconsistencies”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b28]<tuple_delimiter>technical debt<tuple_delimiter>“investigated technical debt, including methods for detecting code comment inconsistencies”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b29]<tuple_delimiter>self-admitted technical debt<tuple_delimiter>“examined self-admitted technical debt to facilitate software maintenance”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b30]<tuple_delimiter>self-admitted technical debt<tuple_delimiter>“examined self-admitted technical debt to facilitate software maintenance”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b31]<tuple_delimiter>API documentation<tuple_delimiter>“introduced a technique for augmenting API documentation content”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b31]<tuple_delimiter>Stack Overflow<tuple_delimiter>“incorporated information from Stack Overflow to augment API documentation”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b32]<tuple_delimiter>development tasks<tuple_delimiter>“extracted development tasks from software documents to bridge documentation and developer needs”<tuple_delimiter>7) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b32]<tuple_delimiter>software documentation<tuple_delimiter>“extracted development tasks from software documents, linking to overall software documentation”<tuple_delimiter>7) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b33]<tuple_delimiter>README files<tuple_delimiter>“mined README files from GitHub and applied transfer learning to simplify complex documentation sentences”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b34]<tuple_delimiter>automatic documentation generation<tuple_delimiter>“proposed a paradigm shift in automatic documentation generation based on developers’ queries”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b0]<tuple_delimiter>installation-related documentation update behaviors<tuple_delimiter>“conducted a qualitative analysis of installation-related documentation update behaviors”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b35]<tuple_delimiter>installation procedures<tuple_delimiter>“highlighted the varying complexity of installation procedures, from fetching binaries to verifying system requirements”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b3]<tuple_delimiter>documentation problems<tuple_delimiter>“identified documentation problems as a barrier for newcomers in OSS repositories”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b3]<tuple_delimiter>development environment configuration<tuple_delimiter>“identified development environment configuration as a barrier for newcomers in OSS repositories”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b3]<tuple_delimiter>OSS repositories<tuple_delimiter>“addressed challenges for newcomers contributing to OSS repositories”<tuple_delimiter>7) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b36]<tuple_delimiter>documentation problems<tuple_delimiter>“identified documentation problems as a barrier for newcomers in OSS repositories”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b36]<tuple_delimiter>development environment configuration<tuple_delimiter>“identified development environment configuration as a barrier for newcomers in OSS repositories”<tuple_delimiter>8) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b36]<tuple_delimiter>OSS repositories<tuple_delimiter>“addressed challenges for newcomers contributing to OSS repositories”<tuple_delimiter>7) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b37]<tuple_delimiter>OSS courses<tuple_delimiter>“found that participation in OSS courses enhances student self-efficacy and impacts perceptions of documentation challenges”<tuple_delimiter>7) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b37]<tuple_delimiter>documentation problems<tuple_delimiter>“increased perception of documentation challenges as identified in the study”<tuple_delimiter>7) 
+{record_delimiter}
+(“relationship”<tuple_delimiter>[371:b1]<tuple_delimiter>README files<tuple_delimiter>“emphasized that README files provide essential “How” instructions for environment setup, installation, and project execution”<tuple_delimiter>8)
+{completion_delimiter}
+
+
+#############################
+
+-Real Data-
+######################
+entity_types: [RESEARCH PAPER, CONCEPT, ORGANIZATION]
+text: {input_text}
+doc_id: {doc_id}
+######################
+output:

--- a/onepiece_rag/prompts/entity_extraction_with_reconstructed_sentence.txt
+++ b/onepiece_rag/prompts/entity_extraction_with_reconstructed_sentence.txt
@@ -48,55 +48,55 @@ TOKEN_b21, TOKEN_b13, and TOKEN_b5 demonstrated that with the advent of fast app
 
 ------------------------
 output:
-(“entity”<tuple_delimiter>[18:b28]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated that for embedding-based recommender systems, large-scale dense similarity search has been applied for retrieval) 
+("entity"<tuple_delimiter>[18:b28]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated that for embedding-based recommender systems, large-scale dense similarity search has been applied for retrieval) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[18:b26]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed utilizing hashing-based techniques by mapping inputs and targets to discrete partitions) 
+("entity"<tuple_delimiter>[18:b26]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed utilizing hashing-based techniques by mapping inputs and targets to discrete partitions) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[18:b21]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval) 
+("entity"<tuple_delimiter>[18:b21]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[18:b13]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval) 
+("entity"<tuple_delimiter>[18:b13]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[18:b5]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval) 
+("entity"<tuple_delimiter>[18:b5]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval) 
 {record_delimiter}
-(“entity”<tuple_delimiter>embedding-based recommender systems<tuple_delimiter>CONCEPT<tuple_delimiter>A concept describing recommender systems that utilize embedding techniques to generate recommendations) 
+("entity"<tuple_delimiter>embedding-based recommender systems<tuple_delimiter>CONCEPT<tuple_delimiter>A concept describing recommender systems that utilize embedding techniques to generate recommendations) 
 {record_delimiter}
-(“entity”<tuple_delimiter>large-scale dense similarity search<tuple_delimiter>CONCEPT<tuple_delimiter>A concept involving the use of dense similarity measures on a large scale for retrieval in recommender systems) 
+("entity"<tuple_delimiter>large-scale dense similarity search<tuple_delimiter>CONCEPT<tuple_delimiter>A concept involving the use of dense similarity measures on a large scale for retrieval in recommender systems) 
 {record_delimiter}
-(“entity”<tuple_delimiter>hashing-based techniques<tuple_delimiter>CONCEPT<tuple_delimiter>A concept involving the use of hashing to map inputs and targets into discrete partitions for efficient retrieval) 
+("entity"<tuple_delimiter>hashing-based techniques<tuple_delimiter>CONCEPT<tuple_delimiter>A concept involving the use of hashing to map inputs and targets into discrete partitions for efficient retrieval) 
 {record_delimiter}
-(“entity”<tuple_delimiter>discrete partitions<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to segregated groups used in hashing-based techniques to cluster inputs and targets) 
+("entity"<tuple_delimiter>discrete partitions<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to segregated groups used in hashing-based techniques to cluster inputs and targets) 
 {record_delimiter}
-(“entity”<tuple_delimiter>fast approximate nearest-neighbor search<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to rapid methods for approximating nearest neighbor search in high-dimensional spaces) 
+("entity"<tuple_delimiter>fast approximate nearest-neighbor search<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to rapid methods for approximating nearest neighbor search in high-dimensional spaces) 
 {record_delimiter}
-(“entity”<tuple_delimiter>recommender systems<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to systems that provide suggestions based on user data) 
+("entity"<tuple_delimiter>recommender systems<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to systems that provide suggestions based on user data) 
 {record_delimiter}
-(“entity”<tuple_delimiter>dense nearest neighbor<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the application of dense vector representations for nearest neighbor search in candidate retrieval) 
+("entity"<tuple_delimiter>dense nearest neighbor<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the application of dense vector representations for nearest neighbor search in candidate retrieval) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b28]<tuple_delimiter>embedding-based recommender systems<tuple_delimiter>“demonstrated the application of large-scale dense similarity search within embedding-based recommender systems”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[18:b28]<tuple_delimiter>embedding-based recommender systems<tuple_delimiter>"demonstrated the application of large-scale dense similarity search within embedding-based recommender systems"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b28]<tuple_delimiter>large-scale dense similarity search<tuple_delimiter>“demonstrated the use of large-scale dense similarity search for retrieval”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[18:b28]<tuple_delimiter>large-scale dense similarity search<tuple_delimiter>"demonstrated the use of large-scale dense similarity search for retrieval"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b26]<tuple_delimiter>hashing-based techniques<tuple_delimiter>“proposed the utilization of hashing-based techniques for mapping inputs and targets”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[18:b26]<tuple_delimiter>hashing-based techniques<tuple_delimiter>"proposed the utilization of hashing-based techniques for mapping inputs and targets"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b26]<tuple_delimiter>discrete partitions<tuple_delimiter>“proposed selecting targets from the same discrete partitions as inputs”<tuple_delimiter>7) 
+("relationship"<tuple_delimiter>[18:b26]<tuple_delimiter>discrete partitions<tuple_delimiter>"proposed selecting targets from the same discrete partitions as inputs"<tuple_delimiter>7) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b21]<tuple_delimiter>fast approximate nearest-neighbor search<tuple_delimiter>“demonstrated the use of fast approximate nearest-neighbor search in candidate retrieval”<tuple_delimiter>9) 
+("relationship"<tuple_delimiter>[18:b21]<tuple_delimiter>fast approximate nearest-neighbor search<tuple_delimiter>"demonstrated the use of fast approximate nearest-neighbor search in candidate retrieval"<tuple_delimiter>9) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b21]<tuple_delimiter>dense nearest neighbor<tuple_delimiter>“demonstrated the application of dense nearest neighbor for candidate retrieval”<tuple_delimiter>9) 
+("relationship"<tuple_delimiter>[18:b21]<tuple_delimiter>dense nearest neighbor<tuple_delimiter>"demonstrated the application of dense nearest neighbor for candidate retrieval"<tuple_delimiter>9) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b13]<tuple_delimiter>fast approximate nearest-neighbor search<tuple_delimiter>“demonstrated the use of fast approximate nearest-neighbor search in candidate retrieval”<tuple_delimiter>9) 
+("relationship"<tuple_delimiter>[18:b13]<tuple_delimiter>fast approximate nearest-neighbor search<tuple_delimiter>"demonstrated the use of fast approximate nearest-neighbor search in candidate retrieval"<tuple_delimiter>9) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b13]<tuple_delimiter>dense nearest neighbor<tuple_delimiter>“demonstrated the application of dense nearest neighbor for candidate retrieval”<tuple_delimiter>9) 
+("relationship"<tuple_delimiter>[18:b13]<tuple_delimiter>dense nearest neighbor<tuple_delimiter>"demonstrated the application of dense nearest neighbor for candidate retrieval"<tuple_delimiter>9) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b5]<tuple_delimiter>fast approximate nearest-neighbor search<tuple_delimiter>“demonstrated the use of fast approximate nearest-neighbor search in candidate retrieval”<tuple_delimiter>9) 
+("relationship"<tuple_delimiter>[18:b5]<tuple_delimiter>fast approximate nearest-neighbor search<tuple_delimiter>"demonstrated the use of fast approximate nearest-neighbor search in candidate retrieval"<tuple_delimiter>9) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b5]<tuple_delimiter>dense nearest neighbor<tuple_delimiter>“demonstrated the application of dense nearest neighbor for candidate retrieval”<tuple_delimiter>9) 
+("relationship"<tuple_delimiter>[18:b5]<tuple_delimiter>dense nearest neighbor<tuple_delimiter>"demonstrated the application of dense nearest neighbor for candidate retrieval"<tuple_delimiter>9) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b21]<tuple_delimiter>recommender systems<tuple_delimiter>“demonstrated that recommender systems applied dense nearest neighbor for candidate retrieval”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[18:b21]<tuple_delimiter>recommender systems<tuple_delimiter>"demonstrated that recommender systems applied dense nearest neighbor for candidate retrieval"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b13]<tuple_delimiter>recommender systems<tuple_delimiter>“demonstrated that recommender systems applied dense nearest neighbor for candidate retrieval”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[18:b13]<tuple_delimiter>recommender systems<tuple_delimiter>"demonstrated that recommender systems applied dense nearest neighbor for candidate retrieval"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[18:b5]<tuple_delimiter>recommender systems<tuple_delimiter>“demonstrated that recommender systems applied dense nearest neighbor for candidate retrieval”<tuple_delimiter>8)
+("relationship"<tuple_delimiter>[18:b5]<tuple_delimiter>recommender systems<tuple_delimiter>"demonstrated that recommender systems applied dense nearest neighbor for candidate retrieval"<tuple_delimiter>8)
 {completion_delimiter}
 
 #############################
@@ -120,61 +120,61 @@ TOKEN_b9 introduced an adaptive routing approach that treated route planning as 
 Their algorithms aimed to reduce the predicted en route trip time while considering broadcasted traffic information, onboard-based traffic state measurements, and historical traffic patterns.
 ------------------------
 output:
-(“entity”<tuple_delimiter>[3:b4]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated the need for smart transportation and traffic management in smart city operations) 
+("entity"<tuple_delimiter>[3:b4]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated the need for smart transportation and traffic management in smart city operations) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[3:b5]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that highlighted significant interest in trip route planning in large and crowded cities) 
+("entity"<tuple_delimiter>[3:b5]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that highlighted significant interest in trip route planning in large and crowded cities) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[3:b6]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed route recommendations based on shorter paths, traffic congestion, and construction works) 
+("entity"<tuple_delimiter>[3:b6]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed route recommendations based on shorter paths, traffic congestion, and construction works) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[3:b7]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper demonstrating that Waze relies on real-time traffic sensing with user intervention) 
+("entity"<tuple_delimiter>[3:b7]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper demonstrating that Waze relies on real-time traffic sensing with user intervention) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[3:b8]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced the APOLO system employing a centralized traffic monitoring approach to reduce travel time and increase speed) 
+("entity"<tuple_delimiter>[3:b8]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced the APOLO system employing a centralized traffic monitoring approach to reduce travel time and increase speed) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[3:b9]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced an adaptive routing approach treating route planning as a probabilistic dynamic problem to reduce en route trip time) 
+("entity"<tuple_delimiter>[3:b9]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced an adaptive routing approach treating route planning as a probabilistic dynamic problem to reduce en route trip time) 
 {record_delimiter}
-(“entity”<tuple_delimiter>smart transportation<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the use of innovative technologies to improve transportation systems in smart cities) 
+("entity"<tuple_delimiter>smart transportation<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the use of innovative technologies to improve transportation systems in smart cities) 
 {record_delimiter}
-(“entity”<tuple_delimiter>traffic management<tuple_delimiter>CONCEPT<tuple_delimiter>A concept involving planning, monitoring, and controlling traffic to optimize road usage and safety) 
+("entity"<tuple_delimiter>traffic management<tuple_delimiter>CONCEPT<tuple_delimiter>A concept involving planning, monitoring, and controlling traffic to optimize road usage and safety) 
 {record_delimiter}
-(“entity”<tuple_delimiter>trip route planning<tuple_delimiter>CONCEPT<tuple_delimiter>A concept related to planning efficient travel routes, especially in crowded urban areas) 
+("entity"<tuple_delimiter>trip route planning<tuple_delimiter>CONCEPT<tuple_delimiter>A concept related to planning efficient travel routes, especially in crowded urban areas) 
 {record_delimiter}
-(“entity”<tuple_delimiter>route recommendations<tuple_delimiter>CONCEPT<tuple_delimiter>A concept where systems suggest optimal travel routes based on factors like distance, congestion, and construction) 
+("entity"<tuple_delimiter>route recommendations<tuple_delimiter>CONCEPT<tuple_delimiter>A concept where systems suggest optimal travel routes based on factors like distance, congestion, and construction) 
 {record_delimiter}
-(“entity”<tuple_delimiter>online dynamic routing<tuple_delimiter>CONCEPT<tuple_delimiter>A concept where routing decisions are updated in real time based on live traffic information) 
+("entity"<tuple_delimiter>online dynamic routing<tuple_delimiter>CONCEPT<tuple_delimiter>A concept where routing decisions are updated in real time based on live traffic information) 
 {record_delimiter}
-(“entity”<tuple_delimiter>centralized traffic monitoring approach<tuple_delimiter>CONCEPT<tuple_delimiter>A concept involving a centralized system to monitor and manage traffic conditions both online and offline) 
+("entity"<tuple_delimiter>centralized traffic monitoring approach<tuple_delimiter>CONCEPT<tuple_delimiter>A concept involving a centralized system to monitor and manage traffic conditions both online and offline) 
 {record_delimiter}
-(“entity”<tuple_delimiter>adaptive routing approach<tuple_delimiter>CONCEPT<tuple_delimiter>A concept that treats route planning as a probabilistic dynamic problem to minimize travel time) 
+("entity"<tuple_delimiter>adaptive routing approach<tuple_delimiter>CONCEPT<tuple_delimiter>A concept that treats route planning as a probabilistic dynamic problem to minimize travel time) 
 {record_delimiter}
-(“entity”<tuple_delimiter>Google<tuple_delimiter>ORGANIZATION<tuple_delimiter>A global technology company involved in route planning and online mapping services) 
+("entity"<tuple_delimiter>Google<tuple_delimiter>ORGANIZATION<tuple_delimiter>A global technology company involved in route planning and online mapping services) 
 {record_delimiter}
-(“entity”<tuple_delimiter>Google Maps<tuple_delimiter>ORGANIZATION<tuple_delimiter>An online mapping service provided by Google offering live traffic data and route suggestions) 
+("entity"<tuple_delimiter>Google Maps<tuple_delimiter>ORGANIZATION<tuple_delimiter>An online mapping service provided by Google offering live traffic data and route suggestions) 
 {record_delimiter}
-(“entity”<tuple_delimiter>Waze<tuple_delimiter>ORGANIZATION<tuple_delimiter>A crowdsensed-based trip planning application that relies on real-time traffic data shared by users) 
+("entity"<tuple_delimiter>Waze<tuple_delimiter>ORGANIZATION<tuple_delimiter>A crowdsensed-based trip planning application that relies on real-time traffic data shared by users) 
 {record_delimiter}
-(“entity”<tuple_delimiter>APOLO system<tuple_delimiter>CONCEPT<tuple_delimiter>A system designed to overcome network overload in traffic management by employing a centralized monitoring approach) 
+("entity"<tuple_delimiter>APOLO system<tuple_delimiter>CONCEPT<tuple_delimiter>A system designed to overcome network overload in traffic management by employing a centralized monitoring approach) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[3:b4]<tuple_delimiter>smart transportation<tuple_delimiter>“demonstrated the need for smart transportation in smart city operations”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[3:b4]<tuple_delimiter>smart transportation<tuple_delimiter>"demonstrated the need for smart transportation in smart city operations"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[3:b4]<tuple_delimiter>traffic management<tuple_delimiter>“demonstrated the critical role of traffic management in daily smart city operations”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[3:b4]<tuple_delimiter>traffic management<tuple_delimiter>"demonstrated the critical role of traffic management in daily smart city operations"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[3:b5]<tuple_delimiter>trip route planning<tuple_delimiter>“highlighted the significance of trip route planning in large and crowded cities”<tuple_delimiter>7) 
+("relationship"<tuple_delimiter>[3:b5]<tuple_delimiter>trip route planning<tuple_delimiter>"highlighted the significance of trip route planning in large and crowded cities"<tuple_delimiter>7) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[3:b6]<tuple_delimiter>route recommendations<tuple_delimiter>“proposed route recommendations based on shorter paths and traffic conditions”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[3:b6]<tuple_delimiter>route recommendations<tuple_delimiter>"proposed route recommendations based on shorter paths and traffic conditions"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>Google Maps<tuple_delimiter>online dynamic routing<tuple_delimiter>“demonstrates online dynamic routing by providing vehicle re-routing suggestions based on live traffic data”<tuple_delimiter>9) 
+("relationship"<tuple_delimiter>Google Maps<tuple_delimiter>online dynamic routing<tuple_delimiter>"demonstrates online dynamic routing by providing vehicle re-routing suggestions based on live traffic data"<tuple_delimiter>9) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[3:b7]<tuple_delimiter>Waze<tuple_delimiter>“demonstrated that Waze relies on real-time traffic sensing and user intervention”<tuple_delimiter>7) 
+("relationship"<tuple_delimiter>[3:b7]<tuple_delimiter>Waze<tuple_delimiter>"demonstrated that Waze relies on real-time traffic sensing and user intervention"<tuple_delimiter>7) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[3:b8]<tuple_delimiter>APOLO system<tuple_delimiter>“introduced the APOLO system to mitigate network overload in traffic management systems”<tuple_delimiter>9) 
+("relationship"<tuple_delimiter>[3:b8]<tuple_delimiter>APOLO system<tuple_delimiter>"introduced the APOLO system to mitigate network overload in traffic management systems"<tuple_delimiter>9) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[3:b8]<tuple_delimiter>centralized traffic monitoring approach<tuple_delimiter>“proposed a centralized approach to monitor traffic both online and offline”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[3:b8]<tuple_delimiter>centralized traffic monitoring approach<tuple_delimiter>"proposed a centralized approach to monitor traffic both online and offline"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[3:b9]<tuple_delimiter>adaptive routing approach<tuple_delimiter>“introduced an adaptive routing approach treating route planning as a probabilistic dynamic problem”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[3:b9]<tuple_delimiter>adaptive routing approach<tuple_delimiter>"introduced an adaptive routing approach treating route planning as a probabilistic dynamic problem"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>Google<tuple_delimiter>Google Maps<tuple_delimiter>“Google Maps is a service provided by Google, integrating live traffic data for route planning”<tuple_delimiter>10) 
+("relationship"<tuple_delimiter>Google<tuple_delimiter>Google Maps<tuple_delimiter>"Google Maps is a service provided by Google, integrating live traffic data for route planning"<tuple_delimiter>10) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>trip route planning<tuple_delimiter>route recommendations<tuple_delimiter>“route recommendations are integral to effective trip route planning”<tuple_delimiter>7)
+("relationship"<tuple_delimiter>trip route planning<tuple_delimiter>route recommendations<tuple_delimiter>"route recommendations are integral to effective trip route planning"<tuple_delimiter>7)
 {completion_delimiter}
 
 
@@ -196,160 +196,160 @@ TOKEN_b0 conducted a qualitative analysis of installation-related documentation 
 TOKEN_b35 highlighted that installation procedures vary in complexity, ranging from fetching a remote binary file to verifying system requirements, resolving dependencies, and ensuring component integrity.
 TOKEN_b3 and TOKEN_b36 identified documentation problems and development environment configuration as significant barriers for newcomers contributing to Open Source Software (OSS) repositories.
 TOKEN_b37 found that participation in OSS courses enhances student self-efficacy while also increasing their perception of documentation challenges, particularly regarding development environment setup.
-TOKEN_b1 emphasized that the primary content category of README files is “How,” covering instructions from environment setup to installation and project execution, reinforcing their essential role in guiding newcomers and software users.
+TOKEN_b1 emphasized that the primary content category of README files is "How," covering instructions from environment setup to installation and project execution, reinforcing their essential role in guiding newcomers and software users.
 In contrast to previous studies focusing on the human perspective of OSS barriers for newcomers, TOKEN_b0 synthesized empirical evidence on software documentation activities related to installation by analyzing a large-scale dataset.
 This empirical evidence will contribute to mitigating documentation-related barriers for newcomers engaging with OSS projects.
 ------------------------
 output:
-(“entity”<tuple_delimiter>[371:b16]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated advancements in code summarization by developing techniques for generating code comments) 
+("entity"<tuple_delimiter>[371:b16]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated advancements in code summarization by developing techniques for generating code comments) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b17]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated advancements in code summarization by developing techniques for generating code comments) 
+("entity"<tuple_delimiter>[371:b17]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated advancements in code summarization by developing techniques for generating code comments) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b18]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated advancements in code summarization by developing techniques for generating code comments) 
+("entity"<tuple_delimiter>[371:b18]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated advancements in code summarization by developing techniques for generating code comments) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b19]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated advancements in code summarization by developing techniques for generating code comments) 
+("entity"<tuple_delimiter>[371:b19]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that demonstrated advancements in code summarization by developing techniques for generating code comments) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b20]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced methods for generating commit messages) 
+("entity"<tuple_delimiter>[371:b20]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced methods for generating commit messages) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b21]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced methods for generating commit messages) 
+("entity"<tuple_delimiter>[371:b21]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced methods for generating commit messages) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b22]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced methods for generating commit messages) 
+("entity"<tuple_delimiter>[371:b22]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced methods for generating commit messages) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b23]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that contributed to the generation of code reviews) 
+("entity"<tuple_delimiter>[371:b23]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that contributed to the generation of code reviews) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b24]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that contributed to the generation of code reviews) 
+("entity"<tuple_delimiter>[371:b24]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that contributed to the generation of code reviews) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b25]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed techniques for creating release notes) 
+("entity"<tuple_delimiter>[371:b25]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed techniques for creating release notes) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b26]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed techniques for creating release notes) 
+("entity"<tuple_delimiter>[371:b26]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed techniques for creating release notes) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b27]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that investigated technical debt, including methods for detecting code comment inconsistencies) 
+("entity"<tuple_delimiter>[371:b27]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that investigated technical debt, including methods for detecting code comment inconsistencies) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b28]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that investigated technical debt, including methods for detecting code comment inconsistencies) 
+("entity"<tuple_delimiter>[371:b28]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that investigated technical debt, including methods for detecting code comment inconsistencies) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b29]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that examined self-admitted technical debt to facilitate software maintenance) 
+("entity"<tuple_delimiter>[371:b29]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that examined self-admitted technical debt to facilitate software maintenance) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b30]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that examined self-admitted technical debt to facilitate software maintenance) 
+("entity"<tuple_delimiter>[371:b30]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that examined self-admitted technical debt to facilitate software maintenance) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b31]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced a technique for augmenting API documentation content by incorporating information from Stack Overflow) 
+("entity"<tuple_delimiter>[371:b31]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that introduced a technique for augmenting API documentation content by incorporating information from Stack Overflow) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b32]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that extracted development tasks from software documents to bridge the gap between software documentation and developers’ information needs) 
+("entity"<tuple_delimiter>[371:b32]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that extracted development tasks from software documents to bridge the gap between software documentation and developers’ information needs) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b33]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that mined README files from GitHub and applied transfer learning to simplify complex documentation sentences) 
+("entity"<tuple_delimiter>[371:b33]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that mined README files from GitHub and applied transfer learning to simplify complex documentation sentences) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b34]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed a paradigm shift in automatic documentation generation based on developers’ queries within their contexts) 
+("entity"<tuple_delimiter>[371:b34]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that proposed a paradigm shift in automatic documentation generation based on developers’ queries within their contexts) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b0]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that conducted a qualitative analysis of installation-related documentation update behaviors to gain a deeper understanding and motivate automated software tool development for documentation writing) 
+("entity"<tuple_delimiter>[371:b0]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that conducted a qualitative analysis of installation-related documentation update behaviors to gain a deeper understanding and motivate automated software tool development for documentation writing) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b35]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that highlighted the varying complexity of installation procedures, from fetching remote binaries to verifying system requirements and resolving dependencies) 
+("entity"<tuple_delimiter>[371:b35]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that highlighted the varying complexity of installation procedures, from fetching remote binaries to verifying system requirements and resolving dependencies) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b3]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that identified documentation problems and development environment configuration as significant barriers for newcomers contributing to OSS repositories) 
+("entity"<tuple_delimiter>[371:b3]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that identified documentation problems and development environment configuration as significant barriers for newcomers contributing to OSS repositories) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b36]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that identified documentation problems and development environment configuration as significant barriers for newcomers contributing to OSS repositories) 
+("entity"<tuple_delimiter>[371:b36]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that identified documentation problems and development environment configuration as significant barriers for newcomers contributing to OSS repositories) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b37]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that found participation in OSS courses enhances student self-efficacy while increasing perception of documentation challenges, particularly in development environment setup) 
+("entity"<tuple_delimiter>[371:b37]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that found participation in OSS courses enhances student self-efficacy while increasing perception of documentation challenges, particularly in development environment setup) 
 {record_delimiter}
-(“entity”<tuple_delimiter>[371:b1]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that emphasized the primary role of README files in providing “How” instructions from environment setup to project execution for newcomers and software users) 
+("entity"<tuple_delimiter>[371:b1]<tuple_delimiter>RESEARCH PAPER<tuple_delimiter>A research paper that emphasized the primary role of README files in providing "How" instructions from environment setup to project execution for newcomers and software users) 
 {record_delimiter}
-(“entity”<tuple_delimiter>code summarization<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the automated process of summarizing code by generating descriptive comments) 
+("entity"<tuple_delimiter>code summarization<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the automated process of summarizing code by generating descriptive comments) 
 {record_delimiter}
-(“entity”<tuple_delimiter>commit messages<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to messages that describe changes in version control commits) 
+("entity"<tuple_delimiter>commit messages<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to messages that describe changes in version control commits) 
 {record_delimiter}
-(“entity”<tuple_delimiter>code reviews<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the evaluation of code by peers to improve quality) 
+("entity"<tuple_delimiter>code reviews<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the evaluation of code by peers to improve quality) 
 {record_delimiter}
-(“entity”<tuple_delimiter>release notes<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to documentation detailing new features and changes in software releases) 
+("entity"<tuple_delimiter>release notes<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to documentation detailing new features and changes in software releases) 
 {record_delimiter}
-(“entity”<tuple_delimiter>technical debt<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the implied cost of rework due to suboptimal design or implementation choices) 
+("entity"<tuple_delimiter>technical debt<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the implied cost of rework due to suboptimal design or implementation choices) 
 {record_delimiter}
-(“entity”<tuple_delimiter>self-admitted technical debt<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to technical debt explicitly acknowledged by developers through comments or documentation) 
+("entity"<tuple_delimiter>self-admitted technical debt<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to technical debt explicitly acknowledged by developers through comments or documentation) 
 {record_delimiter}
-(“entity”<tuple_delimiter>API documentation<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to documentation that provides details about an application’s programming interface) 
+("entity"<tuple_delimiter>API documentation<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to documentation that provides details about an application’s programming interface) 
 {record_delimiter}
-(“entity”<tuple_delimiter>development tasks<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to assignments and activities extracted from software documents) 
+("entity"<tuple_delimiter>development tasks<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to assignments and activities extracted from software documents) 
 {record_delimiter}
-(“entity”<tuple_delimiter>software documentation<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the process and content involved in documenting software projects) 
+("entity"<tuple_delimiter>software documentation<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the process and content involved in documenting software projects) 
 {record_delimiter}
-(“entity”<tuple_delimiter>README files<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to introductory documentation files that provide instructions and information about a software project) 
+("entity"<tuple_delimiter>README files<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to introductory documentation files that provide instructions and information about a software project) 
 {record_delimiter}
-(“entity”<tuple_delimiter>automatic documentation generation<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the automated creation of documentation based on developer inputs or queries) 
+("entity"<tuple_delimiter>automatic documentation generation<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the automated creation of documentation based on developer inputs or queries) 
 {record_delimiter}
-(“entity”<tuple_delimiter>installation-related documentation update behaviors<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the analysis of changes in documentation associated with software installation processes) 
+("entity"<tuple_delimiter>installation-related documentation update behaviors<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the analysis of changes in documentation associated with software installation processes) 
 {record_delimiter}
-(“entity”<tuple_delimiter>installation procedures<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the set of steps required to install software, including dependency resolution and system requirement verification) 
+("entity"<tuple_delimiter>installation procedures<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the set of steps required to install software, including dependency resolution and system requirement verification) 
 {record_delimiter}
-(“entity”<tuple_delimiter>documentation problems<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to issues or shortcomings in software documentation) 
+("entity"<tuple_delimiter>documentation problems<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to issues or shortcomings in software documentation) 
 {record_delimiter}
-(“entity”<tuple_delimiter>development environment configuration<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the setup and arrangement of tools and settings required for software development) 
+("entity"<tuple_delimiter>development environment configuration<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to the setup and arrangement of tools and settings required for software development) 
 {record_delimiter}
-(“entity”<tuple_delimiter>OSS repositories<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to repositories that host open source software projects) 
+("entity"<tuple_delimiter>OSS repositories<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to repositories that host open source software projects) 
 {record_delimiter}
-(“entity”<tuple_delimiter>OSS courses<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to educational courses related to open source software) 
+("entity"<tuple_delimiter>OSS courses<tuple_delimiter>CONCEPT<tuple_delimiter>A concept referring to educational courses related to open source software) 
 {record_delimiter}
-(“entity”<tuple_delimiter>Stack Overflow<tuple_delimiter>ORGANIZATION<tuple_delimiter>An online platform and community where developers ask and answer programming questions) 
+("entity"<tuple_delimiter>Stack Overflow<tuple_delimiter>ORGANIZATION<tuple_delimiter>An online platform and community where developers ask and answer programming questions) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b16]<tuple_delimiter>code summarization<tuple_delimiter>“demonstrated advancements in code summarization by generating techniques for code comments”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b16]<tuple_delimiter>code summarization<tuple_delimiter>"demonstrated advancements in code summarization by generating techniques for code comments"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b17]<tuple_delimiter>code summarization<tuple_delimiter>“demonstrated advancements in code summarization by generating techniques for code comments”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b17]<tuple_delimiter>code summarization<tuple_delimiter>"demonstrated advancements in code summarization by generating techniques for code comments"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b18]<tuple_delimiter>code summarization<tuple_delimiter>“demonstrated advancements in code summarization by generating techniques for code comments”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b18]<tuple_delimiter>code summarization<tuple_delimiter>"demonstrated advancements in code summarization by generating techniques for code comments"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b19]<tuple_delimiter>code summarization<tuple_delimiter>“demonstrated advancements in code summarization by generating techniques for code comments”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b19]<tuple_delimiter>code summarization<tuple_delimiter>"demonstrated advancements in code summarization by generating techniques for code comments"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b20]<tuple_delimiter>commit messages<tuple_delimiter>“introduced methods for generating commit messages”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b20]<tuple_delimiter>commit messages<tuple_delimiter>"introduced methods for generating commit messages"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b21]<tuple_delimiter>commit messages<tuple_delimiter>“introduced methods for generating commit messages”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b21]<tuple_delimiter>commit messages<tuple_delimiter>"introduced methods for generating commit messages"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b22]<tuple_delimiter>commit messages<tuple_delimiter>“introduced methods for generating commit messages”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b22]<tuple_delimiter>commit messages<tuple_delimiter>"introduced methods for generating commit messages"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b23]<tuple_delimiter>code reviews<tuple_delimiter>“contributed to the generation of code reviews”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b23]<tuple_delimiter>code reviews<tuple_delimiter>"contributed to the generation of code reviews"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b24]<tuple_delimiter>code reviews<tuple_delimiter>“contributed to the generation of code reviews”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b24]<tuple_delimiter>code reviews<tuple_delimiter>"contributed to the generation of code reviews"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b25]<tuple_delimiter>release notes<tuple_delimiter>“proposed techniques for creating release notes”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b25]<tuple_delimiter>release notes<tuple_delimiter>"proposed techniques for creating release notes"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b26]<tuple_delimiter>release notes<tuple_delimiter>“proposed techniques for creating release notes”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b26]<tuple_delimiter>release notes<tuple_delimiter>"proposed techniques for creating release notes"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b27]<tuple_delimiter>technical debt<tuple_delimiter>“investigated technical debt, including methods for detecting code comment inconsistencies”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b27]<tuple_delimiter>technical debt<tuple_delimiter>"investigated technical debt, including methods for detecting code comment inconsistencies"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b28]<tuple_delimiter>technical debt<tuple_delimiter>“investigated technical debt, including methods for detecting code comment inconsistencies”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b28]<tuple_delimiter>technical debt<tuple_delimiter>"investigated technical debt, including methods for detecting code comment inconsistencies"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b29]<tuple_delimiter>self-admitted technical debt<tuple_delimiter>“examined self-admitted technical debt to facilitate software maintenance”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b29]<tuple_delimiter>self-admitted technical debt<tuple_delimiter>"examined self-admitted technical debt to facilitate software maintenance"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b30]<tuple_delimiter>self-admitted technical debt<tuple_delimiter>“examined self-admitted technical debt to facilitate software maintenance”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b30]<tuple_delimiter>self-admitted technical debt<tuple_delimiter>"examined self-admitted technical debt to facilitate software maintenance"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b31]<tuple_delimiter>API documentation<tuple_delimiter>“introduced a technique for augmenting API documentation content”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b31]<tuple_delimiter>API documentation<tuple_delimiter>"introduced a technique for augmenting API documentation content"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b31]<tuple_delimiter>Stack Overflow<tuple_delimiter>“incorporated information from Stack Overflow to augment API documentation”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b31]<tuple_delimiter>Stack Overflow<tuple_delimiter>"incorporated information from Stack Overflow to augment API documentation"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b32]<tuple_delimiter>development tasks<tuple_delimiter>“extracted development tasks from software documents to bridge documentation and developer needs”<tuple_delimiter>7) 
+("relationship"<tuple_delimiter>[371:b32]<tuple_delimiter>development tasks<tuple_delimiter>"extracted development tasks from software documents to bridge documentation and developer needs"<tuple_delimiter>7) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b32]<tuple_delimiter>software documentation<tuple_delimiter>“extracted development tasks from software documents, linking to overall software documentation”<tuple_delimiter>7) 
+("relationship"<tuple_delimiter>[371:b32]<tuple_delimiter>software documentation<tuple_delimiter>"extracted development tasks from software documents, linking to overall software documentation"<tuple_delimiter>7) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b33]<tuple_delimiter>README files<tuple_delimiter>“mined README files from GitHub and applied transfer learning to simplify complex documentation sentences”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b33]<tuple_delimiter>README files<tuple_delimiter>"mined README files from GitHub and applied transfer learning to simplify complex documentation sentences"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b34]<tuple_delimiter>automatic documentation generation<tuple_delimiter>“proposed a paradigm shift in automatic documentation generation based on developers’ queries”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b34]<tuple_delimiter>automatic documentation generation<tuple_delimiter>"proposed a paradigm shift in automatic documentation generation based on developers’ queries"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b0]<tuple_delimiter>installation-related documentation update behaviors<tuple_delimiter>“conducted a qualitative analysis of installation-related documentation update behaviors”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b0]<tuple_delimiter>installation-related documentation update behaviors<tuple_delimiter>"conducted a qualitative analysis of installation-related documentation update behaviors"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b35]<tuple_delimiter>installation procedures<tuple_delimiter>“highlighted the varying complexity of installation procedures, from fetching binaries to verifying system requirements”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b35]<tuple_delimiter>installation procedures<tuple_delimiter>"highlighted the varying complexity of installation procedures, from fetching binaries to verifying system requirements"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b3]<tuple_delimiter>documentation problems<tuple_delimiter>“identified documentation problems as a barrier for newcomers in OSS repositories”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b3]<tuple_delimiter>documentation problems<tuple_delimiter>"identified documentation problems as a barrier for newcomers in OSS repositories"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b3]<tuple_delimiter>development environment configuration<tuple_delimiter>“identified development environment configuration as a barrier for newcomers in OSS repositories”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b3]<tuple_delimiter>development environment configuration<tuple_delimiter>"identified development environment configuration as a barrier for newcomers in OSS repositories"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b3]<tuple_delimiter>OSS repositories<tuple_delimiter>“addressed challenges for newcomers contributing to OSS repositories”<tuple_delimiter>7) 
+("relationship"<tuple_delimiter>[371:b3]<tuple_delimiter>OSS repositories<tuple_delimiter>"addressed challenges for newcomers contributing to OSS repositories"<tuple_delimiter>7) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b36]<tuple_delimiter>documentation problems<tuple_delimiter>“identified documentation problems as a barrier for newcomers in OSS repositories”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b36]<tuple_delimiter>documentation problems<tuple_delimiter>"identified documentation problems as a barrier for newcomers in OSS repositories"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b36]<tuple_delimiter>development environment configuration<tuple_delimiter>“identified development environment configuration as a barrier for newcomers in OSS repositories”<tuple_delimiter>8) 
+("relationship"<tuple_delimiter>[371:b36]<tuple_delimiter>development environment configuration<tuple_delimiter>"identified development environment configuration as a barrier for newcomers in OSS repositories"<tuple_delimiter>8) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b36]<tuple_delimiter>OSS repositories<tuple_delimiter>“addressed challenges for newcomers contributing to OSS repositories”<tuple_delimiter>7) 
+("relationship"<tuple_delimiter>[371:b36]<tuple_delimiter>OSS repositories<tuple_delimiter>"addressed challenges for newcomers contributing to OSS repositories"<tuple_delimiter>7) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b37]<tuple_delimiter>OSS courses<tuple_delimiter>“found that participation in OSS courses enhances student self-efficacy and impacts perceptions of documentation challenges”<tuple_delimiter>7) 
+("relationship"<tuple_delimiter>[371:b37]<tuple_delimiter>OSS courses<tuple_delimiter>"found that participation in OSS courses enhances student self-efficacy and impacts perceptions of documentation challenges"<tuple_delimiter>7) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b37]<tuple_delimiter>documentation problems<tuple_delimiter>“increased perception of documentation challenges as identified in the study”<tuple_delimiter>7) 
+("relationship"<tuple_delimiter>[371:b37]<tuple_delimiter>documentation problems<tuple_delimiter>"increased perception of documentation challenges as identified in the study"<tuple_delimiter>7) 
 {record_delimiter}
-(“relationship”<tuple_delimiter>[371:b1]<tuple_delimiter>README files<tuple_delimiter>“emphasized that README files provide essential “How” instructions for environment setup, installation, and project execution”<tuple_delimiter>8)
+("relationship"<tuple_delimiter>[371:b1]<tuple_delimiter>README files<tuple_delimiter>"emphasized that README files provide essential "How" instructions for environment setup, installation, and project execution"<tuple_delimiter>8)
 {completion_delimiter}
 
 

--- a/onepiece_rag/prompts/evaluate_response.txt
+++ b/onepiece_rag/prompts/evaluate_response.txt
@@ -1,0 +1,34 @@
+---Role--- 
+You are an expert in graph analysis and machine learning with a deep understanding of community dynamics within academic and professional networks. 
+You specialize in using advanced language models to assess the quality of data structures, focusing particularly on graph databases that represent relationships and hierarchies within academic communities.
+
+---Goal--- 
+Your primary objective is to assess the structural integrity and logical consistency of a graph dataset. 
+The graph represents academic papers and their relationships within specific communities. 
+You need to evaluate how accurately and coherently the dataset represents its respective communities, papers, and keywords.
+
+---Input Data Structure--- 
+The dataset is structured with nodes and edges where:
+
+- Nodes represent either a community, a document (doc), or an entity (keyword).
+- Edges denote relationships based on the 'parent' attribute, establishing a hierarchy within the graph.
+- Attributes:
+    - `type`: Specifies whether a node is a 'community', 'doc', or 'entity'.
+    - `explain`: Describes what each node represents, providing context and content of the node.
+    - `parent`: Indicates the parent node to establish hierarchy; '-1' indicates a root node.
+	- `id` : ID of each node.
+
+---Steps---
+Explain Analysis: Review the explain attribute of each node to ensure it aligns with its type and hierarchical position. Communities should accurately encapsulate the themes of their child nodes.
+Hierarchical Relationship Validation: Verify that each node is correctly classified under its appropriate parent, with special attention to root nodes and their immediate children to ensure they represent broad, distinct categories without overlap.
+In-depth Analysis of Duplicate Nodes: Identify any instances of nodes (particularly 'community' or 'doc' types) that appear under multiple parents and assess if these duplications are justified or indicate errors in dataset structuring.
+Network Statistical Analysis: Utilize network analysis tools to calculate and evaluate clustering coefficients, shortest path lengths, and centrality metrics to gauge the graph's connectivity and flow of information.
+
+---Evaluating Criteria---
+Accuracy of Node Placement: Evaluate how logically nodes are placed according to the hierarchy, with clear, justifiable links to their parent nodes. Score: 0-100.
+Relevance and Clarity of Node Explanations: Assess how pertinent and insightful the explanations are, reflecting the node's role and importance within the graph. Score: 0-100.
+Minimization of Duplication: Rate how well the dataset minimizes duplication unless contextually justified (e.g., interdisciplinary topics that span multiple communities). Score: 0-100.
+Network Metrics: Evaluate the network metrics where higher clustering coefficients may indicate well-formed communities, and appropriate centrality measures suggest key nodes are central to information flow. Score: 0-100.
+
+---Output--- 
+Based on the analysis, provide a numerical score for each criterion reflecting the dataset's quality AS WELL AS WHY.

--- a/onepiece_rag/prompts/sentence_reconstruction_prompt.txt
+++ b/onepiece_rag/prompts/sentence_reconstruction_prompt.txt
@@ -1,0 +1,110 @@
+Task: Transform Sentence Structures for Referenced Papers and the Current Paper
+
+Context:  
+You are given a passage containing references to prior research papers (shown as [numbers]) and references to the current paper (e.g., “our paper,” “we,” or “this study”). Your goal is to restructure each relevant sentence to make these references the subjects where it makes logical sense, but without forcing unnatural constructions.
+
+Entities to Modify  
+1. Referenced Papers  
+   - Any citation in the form [X] (e.g., [14], [7]) refers to a previous study.  
+   - Where it fits naturally, transform the citation into the subject of the sentence by replacing “[X]” with {{bX}}.  
+   - Do not rewrite the sentence in an awkward way just to make the citation a subject.
+
+2. Current Paper  
+   - Any phrase referring to the present paper (e.g., “our paper,” “we,” “this study”) is replaced with {{b0}}.  
+   - Treat {{b0}} as a possible subject in the sentence if it flows logically.
+
+---
+
+Transformation Rules  
+
+1. Natural Incorporation of Referenced Papers  
+   - Preserve the original meaning while transforming sentences so that references become natural subjects wherever possible.  
+   - Avoid forcing citations to the front of the sentence if it creates awkward phrasing. Use verbs like “stated that,” “proposed,” “introduced,” or “demonstrated that” to connect citations properly.
+
+2. Current Paper as a Subject  
+   - Replace the original references to the current paper with {{b0}}.  
+   - If it naturally makes sense for {{b0}} to be the subject, reorganize the sentence accordingly.
+
+3. Multiple References  
+   - If a sentence cites more than one paper, combine them appropriately as joint subjects (e.g., “{{b3}} and {{b7}} stated that...”) or separate them if that’s clearer.
+
+4. Logical Consistency  
+   - Keep the sentence’s original intention and context intact. If restructuring creates confusion or awkwardness, leave the citation where it is.
+
+5. Valid Citation Numbers Only  
+   - Only use {{bX}} for citations that explicitly appear in the text.  
+   - Do not introduce or modify citation numbers beyond what is given.
+
+6. Preserve Sentence Count and Order  
+   - If the original passage has N sentences, your output must also have N sentences in the same order.  
+   - For each sentence in the input, either transform it (if needed) or leave it unchanged, but do not merge or split sentences.  
+   - This ensures the output’s sentence count and sequence remain identical to the input.
+
+-Examples-
+######################
+Example 1:
+
+Original:
+<h1>abstract</h1> <p>Candidate retrieval is the first stage in recommendation systems, where a light-weight system is used to retrieve potentially relevant items for an input user
+ These candidate items are then ranked and pruned in later stages of recommender systems using a more complex ranking model
+ As the top of the recommendation funnel, it is important to retrieve a high-recall candidate set to feed into downstream ranking models
+ A common approach is to leverage approximate nearest neighbor (ANN) search from a single dense query embedding; however, this approach this can yield a low-diversity result set with many near duplicates
+ As users often have multiple interests, candidate retrieval should ideally return a diverse set of candidates reflective of the user's multiple interests
+ To this end, we introduce kNN-Embed, a general approach to improving diversity in dense ANN-based retrieval
+ kNN-Embed represents each user as a smoothed mixture over learned item clusters that represent distinct "interests" of the user
+ By querying each of a user's mixture component in proportion to their mixture weights, we retrieve a high-diversity set of candidates reflecting elements from each of a user's interests
+ We experimentally compare kNN-Embed to standard ANN candidate retrieval, and show significant improvements in overall recall and improved diversity across three datasets
+ Accompanying this work, we open source a large Twitter follow-graph dataset1, to spur further research in graph-mining and representation learning for recommender systems
+------------------------
+output:
+<h1>abstract</h1> <p> Candidate retrieval is the first stage in recommendation systems, where a light‐weight system is used to retrieve potentially relevant items for an input user. These candidate items are then ranked and pruned in later stages of recommender systems using a more complex ranking model. As the top of the recommendation funnel, it is important to retrieve a high‐recall candidate set to feed into downstream ranking models. A common approach is to leverage approximate nearest neighbor (ANN) search from a single dense query embedding; however, this approach can yield a low‐diversity result set with many near duplicates. As users often have multiple interests, candidate retrieval should ideally return a diverse set of candidates reflective of the user's multiple interests. To this end, {{b0}} introduce kNN-Embed, a general approach to improving diversity in dense ANN-based retrieval. kNN-Embed represents each user as a smoothed mixture over learned item clusters that represent distinct "interests" of the user. By querying each of a user's mixture component in proportion to their mixture weights, {{b0}} retrieve a high-diversity set of candidates reflecting elements from each of a user's interests. {{b0}} experimentally compare kNN-Embed to standard ANN candidate retrieval, and show significant improvements in overall recall and improved diversity across three datasets. Accompanying this work, {{b0}} open source a large Twitter follow-graph dataset1, to spur further research in graph-mining and representation learning for recommender systems.{completion_delimiter}
+
+######################
+Example 2:
+
+Original:
+<p>Introduction </p><h2>text</h2> <p>Recommendation systems for online services such as e-commerce or social networks present users with suggestions in the form of ranked lists of items [5]
+ </p><h2>publication_ref</h2> <p>['b4'] </p><h2>figure_ref</h2> <p>[] </p><h2>table_ref</h2> <p>[] </p><h2>heading</h2> <p>Related Works </p><h2>text</h2> <p>Traditionally, techniques for candidate retrieval rely on fast, scalable approaches to search large collections for similar sparse vectors [3,1]
+ Approaches apply indexing and optimization strategies to scale sparse similarity search
+ One such strategy builds a static clustering of the entire collection of items; clusters are retrieved based on how well their centroids match the query [25,20]
+ These methods either (1) match the query against clusters of items and rank clusters based on similarity to query or (2) utilize clusters as a form of item smoothing
+------------------------
+output:
+<p>Introduction</p> <h2>text</h2> <p> {{b5}} showed that recommendation systems for online services such as e-commerce or social networks present users with suggestions in the form of ranked lists of items. </p> <h2>publication_ref</h2> <p>['b4']</p> <h2>figure_ref</h2> <p>[]</p> <h2>table_ref</h2> <p>[]</p> <h2>heading</h2> <p>Related Works</p> <h2>text</h2> <p> {{b3}} and {{b1}} demonstrated that techniques for candidate retrieval rely on fast, scalable approaches to search large collections for similar sparse vectors. Approaches apply indexing and optimization strategies to scale sparse similarity search. {{b25}} and {{b20}} proposed a strategy that builds a static clustering of the entire collection of items, retrieving clusters based on how well their centroids match the query. These methods either (1) match the query against clusters of items and rank clusters based on similarity to query or (2) utilize clusters as a form of item smoothing{completion_delimiter}
+
+######################
+Example 3:
+
+Original:
+For embedding-based recommender systems [28], large-scale dense similarity search has been applied for retrieval
+ Some approaches proposed utilize hashing-based techniques such as mapping input and targets to discrete partitions and selecting targets from the same partitions as inputs [26]
+ With the advent of fast approximate nearest-neighbor search [21,13], dense nearest neighbor has been applied by recommender systems for candidate retrieval
+------------------------
+output:
+{{b28}} demonstrated that for embedding-based recommender systems, large-scale dense similarity search has been applied for retrieval. {{b26}} proposed utilizing hashing-based techniques such as mapping input and targets to discrete partitions and selecting targets from the same partitions as inputs. {{b21}} and {{b13}} demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval{completion_delimiter}
+
+######################
+Example 4:
+
+Original:
+When utilizing graph-based embeddings for recommender systems [8], some methods transform single-mode embeddings to multiple modes by clustering user actions.
+ Our method extends upon this idea by incorporating nearest neighbor smoothing to address the sparsity problem of generating mixtures of embeddings for users with few engagements
+------------------------
+output:
+When utilizing graph-based embeddings for recommender systems, {{b8}} demonstrated that some methods transform single-mode embeddings to multiple modes by clustering user actions. {{b0}} extends upon this idea by incorporating nearest neighbor smoothing to address the sparsity problem of generating mixtures of embeddings for users with few engagements.{completion_delimiter}
+
+######################
+Example 5:
+
+Original:
+Smoothing via k-nearest-neighbor search has been applied for better language modeling [16] and machine translation [15]
+ We smooth low-engagement user representations by leveraging engagements from similar users
+------------------------
+output:
+{{b16}} and {{b15}} demonstrated that smoothing via k-nearest-neighbor search has been applied for better language modeling and machine translation. {{b0}} smooth low-engagement user representations by leveraging engagements from similar users.{completion_delimiter}
+
+-Real Data-
+######################
+Original: {text_chunk}
+######################
+output:

--- a/onepiece_rag/prompts/sentence_reconstruction_prompt.txt
+++ b/onepiece_rag/prompts/sentence_reconstruction_prompt.txt
@@ -6,12 +6,12 @@ You are given a passage containing references to prior research papers (shown as
 Entities to Modify  
 1. Referenced Papers  
    - Any citation in the form [X] (e.g., [14], [7]) refers to a previous study.  
-   - Where it fits naturally, transform the citation into the subject of the sentence by replacing “[X]” with {{bX}}.  
+   - Where it fits naturally, transform the citation into the subject of the sentence by replacing “[X]” with TOKEN_bX.  
    - Do not rewrite the sentence in an awkward way just to make the citation a subject.
 
 2. Current Paper  
-   - Any phrase referring to the present paper (e.g., “our paper,” “we,” “this study”) is replaced with {{b0}}.  
-   - Treat {{b0}} as a possible subject in the sentence if it flows logically.
+   - Any phrase referring to the present paper (e.g., “our paper,” “we,” “this study”) is replaced with TOKEN_b0.  
+   - Treat TOKEN_b0 as a possible subject in the sentence if it flows logically.
 
 ---
 
@@ -22,17 +22,17 @@ Transformation Rules
    - Avoid forcing citations to the front of the sentence if it creates awkward phrasing. Use verbs like “stated that,” “proposed,” “introduced,” or “demonstrated that” to connect citations properly.
 
 2. Current Paper as a Subject  
-   - Replace the original references to the current paper with {{b0}}.  
-   - If it naturally makes sense for {{b0}} to be the subject, reorganize the sentence accordingly.
+   - Replace the original references to the current paper with TOKEN_b0.  
+   - If it naturally makes sense for TOKEN_b0 to be the subject, reorganize the sentence accordingly.
 
 3. Multiple References  
-   - If a sentence cites more than one paper, combine them appropriately as joint subjects (e.g., “{{b3}} and {{b7}} stated that...”) or separate them if that’s clearer.
+   - If a sentence cites more than one paper, combine them appropriately as joint subjects (e.g., “TOKEN_b3 and TOKEN_b7 stated that...”) or separate them if that’s clearer.
 
 4. Logical Consistency  
    - Keep the sentence’s original intention and context intact. If restructuring creates confusion or awkwardness, leave the citation where it is.
 
 5. Valid Citation Numbers Only  
-   - Only use {{bX}} for citations that explicitly appear in the text.  
+   - Only use TOKEN_bX for citations that explicitly appear in the text.  
    - Do not introduce or modify citation numbers beyond what is given.
 
 6. Preserve Sentence Count and Order  
@@ -57,7 +57,7 @@ Original:
  Accompanying this work, we open source a large Twitter follow-graph dataset1, to spur further research in graph-mining and representation learning for recommender systems
 ------------------------
 output:
-<h1>abstract</h1> <p> Candidate retrieval is the first stage in recommendation systems, where a light‐weight system is used to retrieve potentially relevant items for an input user. These candidate items are then ranked and pruned in later stages of recommender systems using a more complex ranking model. As the top of the recommendation funnel, it is important to retrieve a high‐recall candidate set to feed into downstream ranking models. A common approach is to leverage approximate nearest neighbor (ANN) search from a single dense query embedding; however, this approach can yield a low‐diversity result set with many near duplicates. As users often have multiple interests, candidate retrieval should ideally return a diverse set of candidates reflective of the user's multiple interests. To this end, {{b0}} introduce kNN-Embed, a general approach to improving diversity in dense ANN-based retrieval. kNN-Embed represents each user as a smoothed mixture over learned item clusters that represent distinct "interests" of the user. By querying each of a user's mixture component in proportion to their mixture weights, {{b0}} retrieve a high-diversity set of candidates reflecting elements from each of a user's interests. {{b0}} experimentally compare kNN-Embed to standard ANN candidate retrieval, and show significant improvements in overall recall and improved diversity across three datasets. Accompanying this work, {{b0}} open source a large Twitter follow-graph dataset1, to spur further research in graph-mining and representation learning for recommender systems.{completion_delimiter}
+<h1>abstract</h1> <p> Candidate retrieval is the first stage in recommendation systems, where a light‐weight system is used to retrieve potentially relevant items for an input user. These candidate items are then ranked and pruned in later stages of recommender systems using a more complex ranking model. As the top of the recommendation funnel, it is important to retrieve a high‐recall candidate set to feed into downstream ranking models. A common approach is to leverage approximate nearest neighbor (ANN) search from a single dense query embedding; however, this approach can yield a low‐diversity result set with many near duplicates. As users often have multiple interests, candidate retrieval should ideally return a diverse set of candidates reflective of the user's multiple interests. To this end, TOKEN_b0 introduce kNN-Embed, a general approach to improving diversity in dense ANN-based retrieval. kNN-Embed represents each user as a smoothed mixture over learned item clusters that represent distinct "interests" of the user. By querying each of a user's mixture component in proportion to their mixture weights, TOKEN_b0 retrieve a high-diversity set of candidates reflecting elements from each of a user's interests. TOKEN_b0 experimentally compare kNN-Embed to standard ANN candidate retrieval, and show significant improvements in overall recall and improved diversity across three datasets. Accompanying this work, TOKEN_b0 open source a large Twitter follow-graph dataset1, to spur further research in graph-mining and representation learning for recommender systems.{completion_delimiter}
 
 ######################
 Example 2:
@@ -70,7 +70,7 @@ Original:
  These methods either (1) match the query against clusters of items and rank clusters based on similarity to query or (2) utilize clusters as a form of item smoothing
 ------------------------
 output:
-<p>Introduction</p> <h2>text</h2> <p> {{b5}} showed that recommendation systems for online services such as e-commerce or social networks present users with suggestions in the form of ranked lists of items. </p> <h2>publication_ref</h2> <p>['b4']</p> <h2>figure_ref</h2> <p>[]</p> <h2>table_ref</h2> <p>[]</p> <h2>heading</h2> <p>Related Works</p> <h2>text</h2> <p> {{b3}} and {{b1}} demonstrated that techniques for candidate retrieval rely on fast, scalable approaches to search large collections for similar sparse vectors. Approaches apply indexing and optimization strategies to scale sparse similarity search. {{b25}} and {{b20}} proposed a strategy that builds a static clustering of the entire collection of items, retrieving clusters based on how well their centroids match the query. These methods either (1) match the query against clusters of items and rank clusters based on similarity to query or (2) utilize clusters as a form of item smoothing{completion_delimiter}
+<p>Introduction</p> <h2>text</h2> <p> TOKEN_b5 showed that recommendation systems for online services such as e-commerce or social networks present users with suggestions in the form of ranked lists of items. </p> <h2>publication_ref</h2> <p>['b4']</p> <h2>figure_ref</h2> <p>[]</p> <h2>table_ref</h2> <p>[]</p> <h2>heading</h2> <p>Related Works</p> <h2>text</h2> <p> TOKEN_b3 and TOKEN_b1 demonstrated that techniques for candidate retrieval rely on fast, scalable approaches to search large collections for similar sparse vectors. Approaches apply indexing and optimization strategies to scale sparse similarity search. TOKEN_b25 and TOKEN_b20 proposed a strategy that builds a static clustering of the entire collection of items, retrieving clusters based on how well their centroids match the query. These methods either (1) match the query against clusters of items and rank clusters based on similarity to query or (2) utilize clusters as a form of item smoothing{completion_delimiter}
 
 ######################
 Example 3:
@@ -81,7 +81,7 @@ For embedding-based recommender systems [28], large-scale dense similarity searc
  With the advent of fast approximate nearest-neighbor search [21,13], dense nearest neighbor has been applied by recommender systems for candidate retrieval
 ------------------------
 output:
-{{b28}} demonstrated that for embedding-based recommender systems, large-scale dense similarity search has been applied for retrieval. {{b26}} proposed utilizing hashing-based techniques such as mapping input and targets to discrete partitions and selecting targets from the same partitions as inputs. {{b21}} and {{b13}} demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval{completion_delimiter}
+TOKEN_b28 demonstrated that for embedding-based recommender systems, large-scale dense similarity search has been applied for retrieval. TOKEN_b26 proposed utilizing hashing-based techniques such as mapping input and targets to discrete partitions and selecting targets from the same partitions as inputs. TOKEN_b21 and TOKEN_b13 demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval{completion_delimiter}
 
 ######################
 Example 4:
@@ -91,7 +91,7 @@ When utilizing graph-based embeddings for recommender systems [8], some methods 
  Our method extends upon this idea by incorporating nearest neighbor smoothing to address the sparsity problem of generating mixtures of embeddings for users with few engagements
 ------------------------
 output:
-When utilizing graph-based embeddings for recommender systems, {{b8}} demonstrated that some methods transform single-mode embeddings to multiple modes by clustering user actions. {{b0}} extends upon this idea by incorporating nearest neighbor smoothing to address the sparsity problem of generating mixtures of embeddings for users with few engagements.{completion_delimiter}
+When utilizing graph-based embeddings for recommender systems, TOKEN_b8 demonstrated that some methods transform single-mode embeddings to multiple modes by clustering user actions. TOKEN_b0 extends upon this idea by incorporating nearest neighbor smoothing to address the sparsity problem of generating mixtures of embeddings for users with few engagements.{completion_delimiter}
 
 ######################
 Example 5:
@@ -101,7 +101,7 @@ Smoothing via k-nearest-neighbor search has been applied for better language mod
  We smooth low-engagement user representations by leveraging engagements from similar users
 ------------------------
 output:
-{{b16}} and {{b15}} demonstrated that smoothing via k-nearest-neighbor search has been applied for better language modeling and machine translation. {{b0}} smooth low-engagement user representations by leveraging engagements from similar users.{completion_delimiter}
+TOKEN_b16 and TOKEN_b15 demonstrated that smoothing via k-nearest-neighbor search has been applied for better language modeling and machine translation. TOKEN_b0 smooth low-engagement user representations by leveraging engagements from similar users.{completion_delimiter}
 
 -Real Data-
 ######################

--- a/onepiece_rag/prompts/sentence_reconstruction_prompt.txt
+++ b/onepiece_rag/prompts/sentence_reconstruction_prompt.txt
@@ -13,6 +13,12 @@ Entities to Modify
    - Any phrase referring to the present paper (e.g., “our paper,” “we,” “this study”) is replaced with TOKEN_b0.  
    - Treat TOKEN_b0 as a possible subject in the sentence if it flows logically.
 
+Return output as a well-formed JSON-formatted string with the following format:
+
+{{
+    "output": "<reconstructed_sentence>",
+}}
+
 ---
 
 Transformation Rules  
@@ -57,8 +63,9 @@ Original:
  Accompanying this work, we open source a large Twitter follow-graph dataset1, to spur further research in graph-mining and representation learning for recommender systems
 ------------------------
 output:
-<h1>abstract</h1> <p> Candidate retrieval is the first stage in recommendation systems, where a light‐weight system is used to retrieve potentially relevant items for an input user. These candidate items are then ranked and pruned in later stages of recommender systems using a more complex ranking model. As the top of the recommendation funnel, it is important to retrieve a high‐recall candidate set to feed into downstream ranking models. A common approach is to leverage approximate nearest neighbor (ANN) search from a single dense query embedding; however, this approach can yield a low‐diversity result set with many near duplicates. As users often have multiple interests, candidate retrieval should ideally return a diverse set of candidates reflective of the user's multiple interests. To this end, TOKEN_b0 introduce kNN-Embed, a general approach to improving diversity in dense ANN-based retrieval. kNN-Embed represents each user as a smoothed mixture over learned item clusters that represent distinct "interests" of the user. By querying each of a user's mixture component in proportion to their mixture weights, TOKEN_b0 retrieve a high-diversity set of candidates reflecting elements from each of a user's interests. TOKEN_b0 experimentally compare kNN-Embed to standard ANN candidate retrieval, and show significant improvements in overall recall and improved diversity across three datasets. Accompanying this work, TOKEN_b0 open source a large Twitter follow-graph dataset1, to spur further research in graph-mining and representation learning for recommender systems.{completion_delimiter}
-
+{{
+   "output": "<h1>abstract</h1> <p> Candidate retrieval is the first stage in recommendation systems, where a light‐weight system is used to retrieve potentially relevant items for an input user. These candidate items are then ranked and pruned in later stages of recommender systems using a more complex ranking model. As the top of the recommendation funnel, it is important to retrieve a high‐recall candidate set to feed into downstream ranking models. A common approach is to leverage approximate nearest neighbor (ANN) search from a single dense query embedding; however, this approach can yield a low‐diversity result set with many near duplicates. As users often have multiple interests, candidate retrieval should ideally return a diverse set of candidates reflective of the user's multiple interests. To this end, TOKEN_b0 introduce kNN-Embed, a general approach to improving diversity in dense ANN-based retrieval. kNN-Embed represents each user as a smoothed mixture over learned item clusters that represent distinct "interests" of the user. By querying each of a user's mixture component in proportion to their mixture weights, TOKEN_b0 retrieve a high-diversity set of candidates reflecting elements from each of a user's interests. TOKEN_b0 experimentally compare kNN-Embed to standard ANN candidate retrieval, and show significant improvements in overall recall and improved diversity across three datasets. Accompanying this work, TOKEN_b0 open source a large Twitter follow-graph dataset1, to spur further research in graph-mining and representation learning for recommender systems."
+}}
 ######################
 Example 2:
 
@@ -70,8 +77,9 @@ Original:
  These methods either (1) match the query against clusters of items and rank clusters based on similarity to query or (2) utilize clusters as a form of item smoothing
 ------------------------
 output:
-<p>Introduction</p> <h2>text</h2> <p> TOKEN_b5 showed that recommendation systems for online services such as e-commerce or social networks present users with suggestions in the form of ranked lists of items. </p> <h2>publication_ref</h2> <p>['b4']</p> <h2>figure_ref</h2> <p>[]</p> <h2>table_ref</h2> <p>[]</p> <h2>heading</h2> <p>Related Works</p> <h2>text</h2> <p> TOKEN_b3 and TOKEN_b1 demonstrated that techniques for candidate retrieval rely on fast, scalable approaches to search large collections for similar sparse vectors. Approaches apply indexing and optimization strategies to scale sparse similarity search. TOKEN_b25 and TOKEN_b20 proposed a strategy that builds a static clustering of the entire collection of items, retrieving clusters based on how well their centroids match the query. These methods either (1) match the query against clusters of items and rank clusters based on similarity to query or (2) utilize clusters as a form of item smoothing{completion_delimiter}
-
+{{
+   "output": "<p>Introduction</p> <h2>text</h2> <p> TOKEN_b5 showed that recommendation systems for online services such as e-commerce or social networks present users with suggestions in the form of ranked lists of items. </p> <h2>publication_ref</h2> <p>['b4']</p> <h2>figure_ref</h2> <p>[]</p> <h2>table_ref</h2> <p>[]</p> <h2>heading</h2> <p>Related Works</p> <h2>text</h2> <p> TOKEN_b3 and TOKEN_b1 demonstrated that techniques for candidate retrieval rely on fast, scalable approaches to search large collections for similar sparse vectors. Approaches apply indexing and optimization strategies to scale sparse similarity search. TOKEN_b25 and TOKEN_b20 proposed a strategy that builds a static clustering of the entire collection of items, retrieving clusters based on how well their centroids match the query. These methods either (1) match the query against clusters of items and rank clusters based on similarity to query or (2) utilize clusters as a form of item smoothing"
+}}
 ######################
 Example 3:
 
@@ -81,7 +89,9 @@ For embedding-based recommender systems [28], large-scale dense similarity searc
  With the advent of fast approximate nearest-neighbor search [21,13], dense nearest neighbor has been applied by recommender systems for candidate retrieval
 ------------------------
 output:
-TOKEN_b28 demonstrated that for embedding-based recommender systems, large-scale dense similarity search has been applied for retrieval. TOKEN_b26 proposed utilizing hashing-based techniques such as mapping input and targets to discrete partitions and selecting targets from the same partitions as inputs. TOKEN_b21 and TOKEN_b13 demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval{completion_delimiter}
+{{
+   "output": "TOKEN_b28 demonstrated that for embedding-based recommender systems, large-scale dense similarity search has been applied for retrieval. TOKEN_b26 proposed utilizing hashing-based techniques such as mapping input and targets to discrete partitions and selecting targets from the same partitions as inputs. TOKEN_b21 and TOKEN_b13 demonstrated that with the advent of fast approximate nearest-neighbor search, recommender systems have applied dense nearest neighbor for candidate retrieval"
+}}
 
 ######################
 Example 4:
@@ -91,7 +101,9 @@ When utilizing graph-based embeddings for recommender systems [8], some methods 
  Our method extends upon this idea by incorporating nearest neighbor smoothing to address the sparsity problem of generating mixtures of embeddings for users with few engagements
 ------------------------
 output:
-When utilizing graph-based embeddings for recommender systems, TOKEN_b8 demonstrated that some methods transform single-mode embeddings to multiple modes by clustering user actions. TOKEN_b0 extends upon this idea by incorporating nearest neighbor smoothing to address the sparsity problem of generating mixtures of embeddings for users with few engagements.{completion_delimiter}
+{{
+   "output": "When utilizing graph-based embeddings for recommender systems, TOKEN_b8 demonstrated that some methods transform single-mode embeddings to multiple modes by clustering user actions. TOKEN_b0 extends upon this idea by incorporating nearest neighbor smoothing to address the sparsity problem of generating mixtures of embeddings for users with few engagements."
+}}
 
 ######################
 Example 5:
@@ -101,10 +113,20 @@ Smoothing via k-nearest-neighbor search has been applied for better language mod
  We smooth low-engagement user representations by leveraging engagements from similar users
 ------------------------
 output:
-TOKEN_b16 and TOKEN_b15 demonstrated that smoothing via k-nearest-neighbor search has been applied for better language modeling and machine translation. TOKEN_b0 smooth low-engagement user representations by leveraging engagements from similar users.{completion_delimiter}
+TOKEN_b16 and TOKEN_b15 demonstrated that smoothing via k-nearest-neighbor search has been applied for better language modeling and machine translation. TOKEN_b0 smooth low-engagement user representations by leveraging engagements from similar users.
 
 -Real Data-
 ######################
-Original: {text_chunk}
+
+Use the following text for your answer. Do not make anything up in your answer.
+
+Original: {input_text}
+
+Return output as a well-formed JSON-formatted string with the following format:
+
+{{
+    "output": "<reconstructed_sentence>",
+}}
+
 ######################
 output:

--- a/onepiece_rag/settings.yaml
+++ b/onepiece_rag/settings.yaml
@@ -143,6 +143,7 @@ global_search:
   map_prompt: "prompts/global_search_map_system_prompt.txt"
   reduce_prompt: "prompts/global_search_reduce_system_prompt.txt"
   knowledge_prompt: "prompts/global_search_knowledge_system_prompt.txt"
-
+  evaluate_prompt: "prompts/evaluate_response.txt"
+  
 drift_search:
   prompt: "prompts/drift_search_system_prompt.txt"

--- a/onepiece_rag/settings.yaml
+++ b/onepiece_rag/settings.yaml
@@ -89,8 +89,8 @@ update_index_storage:
 skip_workflows: []
 
 sentence_reconstruction:
+  enabled: true # if true, will reconstruct input sentences
   prompt: "prompts/sentence_reconstruction_prompt.txt"
-  sentence_reconstruction: true
 
 entity_extraction:
   prompt: "prompts/entity_extraction_with_researchpaper.txt"

--- a/onepiece_rag/settings.yaml
+++ b/onepiece_rag/settings.yaml
@@ -88,6 +88,10 @@ update_index_storage:
 # skip_workflows: [extract_graph, compute_communities, create_final_entities, create_final_relationships, create_final_nodes, create_final_community_reports, create_final_text_units]
 skip_workflows: []
 
+sentence_reconstruction:
+  prompt: "prompts/sentence_reconstruction_prompt.txt"
+  sentence_reconstruction: true
+
 entity_extraction:
   prompt: "prompts/entity_extraction_with_researchpaper.txt"
   entity_types: [RESEARCH PAPER, CONCEPT, ORGANIZATION]

--- a/onepiece_rag/settings.yaml
+++ b/onepiece_rag/settings.yaml
@@ -85,7 +85,6 @@ update_index_storage:
 
 ### Workflow settings ###
 
-# skip_workflows: [extract_graph, compute_communities, create_final_entities, create_final_relationships, create_final_nodes, create_final_community_reports, create_final_text_units]
 skip_workflows: []
 
 sentence_reconstruction:
@@ -93,7 +92,8 @@ sentence_reconstruction:
   prompt: "prompts/sentence_reconstruction_prompt.txt"
 
 entity_extraction:
-  prompt: "prompts/entity_extraction_with_researchpaper.txt"
+  # sentence reconstruction이 활성화되어 있지 않을 경우, entity_extraction_with_researchpaper.txt를 사용해야 함
+  prompt: "prompts/entity_extraction_with_reconstructed_sentence.txt"
   entity_types: [RESEARCH PAPER, CONCEPT, ORGANIZATION]
   max_gleanings: 1
   use_doc_id: true


### PR DESCRIPTION
#  Note
**refactor/process_documents에서 분기된 브랜치입니다. #20**
**해당 브랜치로 머지하고 싶어서, base branch를 refactor/process_documents로 설정했습니다.**

## 개요

아래 두 가지 목적을 달성하기 위해, 입력 text chunk의 문장 구조를 재구조화 하는 방법을 도입합니다.

- extracted paper entity  양 증대
- paper entity 간의 extracted relationship 양 증대

## 작업 내용
[PRD 문서](https://www.notion.so/162d2f288baf80739a1df8d2b4e9ad64?v=bd8dbb251b0a4b829151b23fa990acfb&p=19ed2f288baf8089a440deb2a84b24e7&pm=s)
[TechSpec 문서](https://www.notion.so/TechSpec-Augmenting-paper-entity-relationships-1abd2f288baf800a8f5cf2c4c173c8ed)

1. **configurable sentence reconstruction**: 
`settings.yaml`의 sentence_reconstruction 아래 `enabled` 값을 True로 설정하면 reconstruction, false의 경우 기존과 같이 코드가 굴러가도록 구현했습니다.
2. **sentence reconstruction prompt**
문장이 GraphExtractor에 의해 entity & relation이 추출되기 전, 문장의 구조를 바꿀 수 있는 프롬프트를 생성했습니다.
3. **code convention**:
기존 코드와의 통일성을 위해 최대한 convention을 지키며 구현했습니다.