### PR TITLE
operation: increase api request limit

### DIFF
--- a/onepiece_rag/settings.yaml
+++ b/onepiece_rag/settings.yaml
@@ -11,8 +11,8 @@ llm:
   type: openai_chat # or azure_openai_chat
   model: gpt-4o-mini
   max_retries: 20
-  tokens_per_minute: 200000
-  requests_per_minute: 500
+  tokens_per_minute: 2000000
+  requests_per_minute: 5000
   model_supports_json: true # recommended if this is available for your model.
   # audience: "https://cognitiveservices.azure.com/.default"
   # api_base: https://<instance>.openai.azure.com
@@ -22,7 +22,7 @@ llm:
 
 parallelization:
   stagger: 0.3
-  num_threads: 4
+  num_threads: 20
 
 async_mode: asyncio # or asyncio
 
@@ -40,7 +40,7 @@ embeddings:
     model: text-embedding-3-small
     max_retries: 20
     tokens_per_minute: 1000000
-    requests_per_minute: 3000
+    requests_per_minute: 5000
     # api_base: https://<instance>.openai.azure.com
     # api_version: 2024-02-15-preview
     # audience: "https://cognitiveservices.azure.com/.default"
@@ -87,19 +87,16 @@ update_index_storage:
 
 skip_workflows: []
 
-
-equation_interpretation:
-  enabled: True # if true, will interpret equation in input sentences
-  prompt: "prompts/equation_interpretation_prompt.txt"
 sentence_reconstruction:
   enabled: true # if true, will reconstruct input sentences
   prompt: "prompts/sentence_reconstruction_prompt.txt"
 
 entity_extraction:
   # sentence reconstruction이 활성화되어 있지 않을 경우, entity_extraction_with_researchpaper.txt를 사용해야 함
-  prompt: "prompts/entity_extraction_with_reconstructed_sentence.txt"
+  # prompt: "prompts/entity_extraction_with_reconstructed_sentence.txt"
+  prompt: "prompts/entity_extraction_with_researchpaper.txt"
   entity_types: [RESEARCH PAPER, CONCEPT, ORGANIZATION]
-  max_gleanings: 1
+  max_gleanings: 3
   use_doc_id: true
 
 summarize_descriptions:
@@ -151,7 +148,7 @@ global_search:
   map_prompt: "prompts/global_search_map_system_prompt.txt"
   reduce_prompt: "prompts/global_search_reduce_system_prompt.txt"
   knowledge_prompt: "prompts/global_search_knowledge_system_prompt.txt"
-  evaluate_prompt: "prompts/evaluate_graph.txt"
-  
+  evaluate_prompt: "prompts/evaluate_response.txt"
+
 drift_search:
   prompt: "prompts/drift_search_system_prompt.txt"


### PR DESCRIPTION
## 개요

- openai api rate limit을 늘리고 싶습니다.

## 작업 내용

- 이용량이 늘어, 우리 계정의 tier가 `Tier 1`에서 `Tier 2`로 레벨업 되었습니다.
- 이에 따라 api rate limit을 수정합니다.

속도 차이

| 기준                          | 수정 전 | 수정 후 | 개선 폭 (%)  |
|-------------------------------|--------|--------|------------|
| **Interpretating Equations**  | 1분 13초 (73초) | 15초  | **79.45%** |
| **Reconstructing sentences**  | 1분 5초 (65초)  | 20초  | **69.23%** |
| **extract graph**             | 1분 56초 (116초) | 1분 21초 (81초) | **30.17%** |
| **prepare_community_reports** | 1분 28초 (88초)  | 24초  | **72.73%** |
| **extract_core_concept**      | 9초     | 3초    | **66.67%** |