### PR TITLE
refactor: split evaluation mode into two separate modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,3 @@ example
 onepiece_rag/*
 !onepiece_rag/settings.yaml
 !onepiece_rag/prompts
-
-baseline/
-baseline_chunk600/
-baseline_gleaning3/
-srec/
-srec_chunk600/
-srec_gleaning3/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@ example
 onepiece_rag/*
 !onepiece_rag/settings.yaml
 !onepiece_rag/prompts
+
+baseline/
+baseline_chunk600/
+baseline_gleaning3/
+srec/
+srec_chunk600/
+srec_gleaning3/

--- a/graphrag/cli/evaluate.py
+++ b/graphrag/cli/evaluate.py
@@ -18,6 +18,7 @@ from graphrag.index.create_pipeline_config import create_pipeline_config
 from graphrag.logger.print_progress import PrintProgressLogger
 from graphrag.storage.factory import StorageFactory
 from graphrag.utils.storage import load_table_from_storage
+from graphrag.utils.cli import _resolve_output_files
 
 logger = PrintProgressLogger("")
 
@@ -106,37 +107,3 @@ def _run_evaluate(
 
     logger.success(f"Evaluate Response: \n{response}")
     return response, context_data
-
-def _resolve_output_files(
-    config: GraphRagConfig,
-    output_list: list[str],
-    optional_list: list[str] | None = None,
-) -> dict[str, pd.DataFrame]:
-    """Read indexing output files to a dataframe dict."""
-    dataframe_dict = {}
-    pipeline_config = create_pipeline_config(config)
-    storage_config = pipeline_config.storage.model_dump()  # type: ignore
-    storage_obj = StorageFactory().create_storage(
-        storage_type=storage_config["type"], kwargs=storage_config
-    )
-    for output_file in output_list:
-        df_key = output_file.split(".")[0]
-        df_value = asyncio.run(
-            load_table_from_storage(name=output_file, storage=storage_obj)
-        )
-        dataframe_dict[df_key] = df_value
-
-    # for optional output files, set the dict entry to None instead of erroring out if it does not exist
-    if optional_list:
-        for optional_file in optional_list:
-            file_exists = asyncio.run(storage_obj.has(optional_file))
-            df_key = optional_file.split(".")[0]
-            if file_exists:
-                df_value = asyncio.run(
-                    load_table_from_storage(name=optional_file, storage=storage_obj)
-                )
-                dataframe_dict[df_key] = df_value
-            else:
-                dataframe_dict[df_key] = None
-
-    return dataframe_dict

--- a/graphrag/cli/evaluate.py
+++ b/graphrag/cli/evaluate.py
@@ -14,6 +14,7 @@ import graphrag.api as api
 from graphrag.config.load_config import load_config
 from graphrag.config.models.graph_rag_config import GraphRagConfig
 from graphrag.config.resolve_path import resolve_paths
+from graphrag.evaluate.load_graph import read_graph
 from graphrag.index.create_pipeline_config import create_pipeline_config
 from graphrag.logger.print_progress import PrintProgressLogger
 from graphrag.storage.factory import StorageFactory
@@ -22,12 +23,13 @@ from graphrag.utils.cli import _resolve_output_files
 
 logger = PrintProgressLogger("")
 
-def evaluate_cli(
+def evaluate_index(
     config_filepath: Path | None,
     root_exp: Path,
     root_ctl: Path,
     response_type: str,
     dry_run: bool,
+    evaluate_files: list[str] = ["create_final_nodes.parquet", "create_final_entities.parquet", "create_final_communities.parquet", "create_final_community_reports.parquet"]
 ):
     """Run the pipeline with the given config."""
     root = root_exp.resolve()
@@ -35,60 +37,8 @@ def evaluate_cli(
 
     root = root_ctl.resolve()
     config_ctl = load_config(root, config_filepath)
-    _run_evaluate(
-        config_exp=config_exp,
-        config_ctl=config_ctl,
-        dry_run=dry_run,
-        response_type=response_type,
-    )
 
-def _run_evaluate(
-    config_exp,
-    config_ctl,
-    dry_run,
-    response_type,
-):
-    """Perform the actual pipeline to evaluate LLM responses.
-
-    Loads index files required for evaluation and runs the evaluation pipeline."""
-
-    # config.storage.base_dir = str(data_dir) if data_dir else config.storage.base_dir
-    resolve_paths(config_exp)
-    resolve_paths(config_ctl)
-
-    dataframe_dict_exp = _resolve_output_files(
-        config=config_exp,
-        output_list=[
-            "create_final_nodes.parquet",
-            "create_final_entities.parquet",
-            "create_final_communities.parquet",
-            "create_final_community_reports.parquet",
-        ],
-        optional_list=[],
-    )
-    final_nodes_exp: pd.DataFrame = dataframe_dict_exp["create_final_nodes"]
-    final_entities_exp: pd.DataFrame = dataframe_dict_exp["create_final_entities"]
-    final_communities_exp: pd.DataFrame = dataframe_dict_exp["create_final_communities"]
-    final_community_reports_exp: pd.DataFrame = dataframe_dict_exp[
-        "create_final_community_reports"
-    ]
-
-    dataframe_dict_ctl = _resolve_output_files(
-        config=config_ctl,
-        output_list=[
-            "create_final_nodes.parquet",
-            "create_final_entities.parquet",
-            "create_final_communities.parquet",
-            "create_final_community_reports.parquet",
-        ],
-        optional_list=[],
-    )
-    final_nodes_ctl: pd.DataFrame = dataframe_dict_ctl["create_final_nodes"]
-    final_entities_ctl: pd.DataFrame = dataframe_dict_ctl["create_final_entities"]
-    final_communities_ctl: pd.DataFrame = dataframe_dict_ctl["create_final_communities"]
-    final_community_reports_ctl: pd.DataFrame = dataframe_dict_ctl[
-        "create_final_community_reports"
-    ]
+    exp_dict, ctl_dict = read_graph(config_exp, evaluate_files), read_graph(config_ctl, evaluate_files)
 
     if dry_run:
         logger.success("Dry run complete, exiting...")
@@ -97,13 +47,27 @@ def _run_evaluate(
     response, context_data = asyncio.run(
         api.evaluate_graph(
             config=(config_exp, config_ctl),
-            nodes=(final_nodes_exp, final_nodes_ctl),
-            entities=(final_entities_exp, final_entities_ctl),
-            communities=(final_communities_exp, final_communities_ctl),
-            community_reports=(final_community_reports_exp, final_community_reports_ctl),
+            nodes=(exp_dict["create_final_nodes"], ctl_dict["create_final_nodes"]),
+            entities=(exp_dict["create_final_entities"], ctl_dict["create_final_entities"]),
+            communities=(exp_dict["create_final_communities"], ctl_dict["create_final_communities"]),
+            community_reports=(exp_dict["create_final_community_reports"], ctl_dict["create_final_community_reports"]),
             response_type=response_type,
         )
     )
 
     logger.success(f"Evaluate Response: \n{response}")
     return response, context_data
+
+
+def evaluate_query(
+    config_filepath: Path | None,
+    root_exp: Path,
+    response_type: str,
+    dry_run: bool,
+    evaluate_files: list[str] = ["create_final_nodes.parquet", "create_final_entities.parquet", "create_final_communities.parquet", "create_final_community_reports.parquet"]
+):
+    """Run the pipeline with the given config."""
+    root = root_exp.resolve()
+    config_exp = load_config(root, config_filepath)
+
+    assert False, "Not implemented yet"

--- a/graphrag/cli/main.py
+++ b/graphrag/cli/main.py
@@ -495,7 +495,7 @@ def _query_cli(
 
 @app.command("evaluate")
 def _evaluate_cli(
-    method: Annotated[SearchType, typer.Option(help="The evaluation algorithm to use.")],
+    method: Annotated[EvalType, typer.Option(help="The evaluation algorithm to use.")],
     config: Annotated[
         Path | None,
         typer.Option(

--- a/graphrag/cli/main.py
+++ b/graphrag/cli/main.py
@@ -96,6 +96,18 @@ class SearchType(Enum):
         return self.value
 
 
+class EvalType(Enum):
+    """The type of evaluation to run."""
+
+    INDEX = "index"
+    QUERY = "query"
+    BOTH = "both"
+
+    def __str__(self):
+        """Return the string representation of the enum value."""
+        return self.value
+
+
 @app.command("init")
 def _initialize_cli(
     root: Annotated[
@@ -483,6 +495,7 @@ def _query_cli(
 
 @app.command("evaluate")
 def _evaluate_cli(
+    method: Annotated[SearchType, typer.Option(help="The evaluation algorithm to use.")],
     config: Annotated[
         Path | None,
         typer.Option(
@@ -495,7 +508,7 @@ def _evaluate_cli(
             ),
         ),
     ] = None,
-    root1: Annotated[
+    root_exp: Annotated[
         Path,
         typer.Option(
             help="The project root directory.",
@@ -508,7 +521,7 @@ def _evaluate_cli(
             ),
         ),
     ] = Path(),  # set default to current directory
-    root2: Annotated[
+    root_ctl: Annotated[
         Path,
         typer.Option(
             help="The second project root directory.",
@@ -534,14 +547,36 @@ def _evaluate_cli(
         ),
     ] = False,
 ):
-    # print("Evaluation is not supported yet.")
     """Evaluate a knowledge graph index."""
-    from graphrag.cli.evaluate import evaluate_cli
+    from graphrag.cli.evaluate import evaluate_index, evaluate_query
 
-    evaluate_cli(
-        config_filepath=config,
-        root_dir1=root1,
-        root_dir2=root2,
-        response_type=response_type,
-        dry_run=dry_run,
-    )
+    match method:
+        case EvalType.INDEX:
+            evaluate_index(
+                config_filepath=config,
+                root_exp=root_exp,
+                root_ctl=root_ctl,
+                response_type=response_type,
+                dry_run=dry_run,
+            )
+        case EvalType.QUERY:
+            evaluate_query(
+                config_filepath=config,
+                root_exp=root_exp,
+                response_type=response_type,
+                dry_run=dry_run,
+            )
+        case EvalType.BOTH:
+            evaluate_index(
+                config_filepath=config,
+                root_exp=root_exp,
+                root_ctl=root_ctl,
+                response_type=response_type,
+                dry_run=dry_run,
+            )
+            evaluate_query(
+                config_filepath=config,
+                root_exp=root_exp,
+                response_type=response_type,
+                dry_run=dry_run,
+            )

--- a/graphrag/cli/query.py
+++ b/graphrag/cli/query.py
@@ -17,7 +17,7 @@ from graphrag.index.create_pipeline_config import create_pipeline_config
 from graphrag.logger.print_progress import PrintProgressLogger
 from graphrag.storage.factory import StorageFactory
 from graphrag.utils.storage import load_table_from_storage
-
+from graphrag.utils.cli import _resolve_output_files
 logger = PrintProgressLogger("")
 
 
@@ -255,38 +255,3 @@ def run_drift_search(
     # External users should use the API directly to get the response and context data.
     # TODO: Map/Reduce Drift Search answer to a single response
     return response, context_data
-
-
-def _resolve_output_files(
-    config: GraphRagConfig,
-    output_list: list[str],
-    optional_list: list[str] | None = None,
-) -> dict[str, pd.DataFrame]:
-    """Read indexing output files to a dataframe dict."""
-    dataframe_dict = {}
-    pipeline_config = create_pipeline_config(config)
-    storage_config = pipeline_config.storage.model_dump()  # type: ignore
-    storage_obj = StorageFactory().create_storage(
-        storage_type=storage_config["type"], kwargs=storage_config
-    )
-    for output_file in output_list:
-        df_key = output_file.split(".")[0]
-        df_value = asyncio.run(
-            load_table_from_storage(name=output_file, storage=storage_obj)
-        )
-        dataframe_dict[df_key] = df_value
-
-    # for optional output files, set the dict entry to None instead of erroring out if it does not exist
-    if optional_list:
-        for optional_file in optional_list:
-            file_exists = asyncio.run(storage_obj.has(optional_file))
-            df_key = optional_file.split(".")[0]
-            if file_exists:
-                df_value = asyncio.run(
-                    load_table_from_storage(name=optional_file, storage=storage_obj)
-                )
-                dataframe_dict[df_key] = df_value
-            else:
-                dataframe_dict[df_key] = None
-
-    return dataframe_dict

--- a/graphrag/evaluate/load_graph.py
+++ b/graphrag/evaluate/load_graph.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""Graph reader implementation"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+import graphrag.api as api
+from graphrag.config.load_config import load_config
+from graphrag.config.models.graph_rag_config import GraphRagConfig
+from graphrag.config.resolve_path import resolve_paths
+from graphrag.index.create_pipeline_config import create_pipeline_config
+from graphrag.logger.print_progress import PrintProgressLogger
+from graphrag.storage.factory import StorageFactory
+from graphrag.utils.storage import load_table_from_storage
+from graphrag.utils.cli import _resolve_output_files
+
+
+def read_graph(config: GraphRagConfig, file_to_read: list[str]) -> dict[str, pd.DataFrame]:
+    resolve_paths(config)
+
+    dataframe_dict: dict[str, pd.DataFrame] = _resolve_output_files(
+        config=config,
+        output_list=file_to_read,
+        optional_list=[],
+    )
+
+    return dataframe_dict

--- a/graphrag/utils/cli.py
+++ b/graphrag/utils/cli.py
@@ -3,10 +3,15 @@
 
 """CLI functions for the GraphRAG module."""
 
+import asyncio
+import pandas as pd
 import argparse
 import json
 from pathlib import Path
-
+from graphrag.config.models.graph_rag_config import GraphRagConfig
+from graphrag.index.create_pipeline_config import create_pipeline_config
+from graphrag.storage.factory import StorageFactory
+from graphrag.utils.storage import load_table_from_storage
 
 def file_exist(path):
     """Check for file existence."""
@@ -52,3 +57,38 @@ def redact(config: dict) -> str:
 
     redacted_dict = redact_dict(config)
     return json.dumps(redacted_dict, indent=4)
+
+
+def _resolve_output_files(
+    config: GraphRagConfig,
+    output_list: list[str],
+    optional_list: list[str] | None = None,
+) -> dict[str, pd.DataFrame]:
+    """Read indexing output files to a dataframe dict."""
+    dataframe_dict = {}
+    pipeline_config = create_pipeline_config(config)
+    storage_config = pipeline_config.storage.model_dump()  # type: ignore
+    storage_obj = StorageFactory().create_storage(
+        storage_type=storage_config["type"], kwargs=storage_config
+    )
+    for output_file in output_list:
+        df_key = output_file.split(".")[0]
+        df_value = asyncio.run(
+            load_table_from_storage(name=output_file, storage=storage_obj)
+        )
+        dataframe_dict[df_key] = df_value
+
+    # for optional output files, set the dict entry to None instead of erroring out if it does not exist
+    if optional_list:
+        for optional_file in optional_list:
+            file_exists = asyncio.run(storage_obj.has(optional_file))
+            df_key = optional_file.split(".")[0]
+            if file_exists:
+                df_value = asyncio.run(
+                    load_table_from_storage(name=optional_file, storage=storage_obj)
+                )
+                dataframe_dict[df_key] = df_value
+            else:
+                dataframe_dict[df_key] = None
+
+    return dataframe_dict


### PR DESCRIPTION
## 개요

- MAP에 필요한 evaluation은 index, query로 두 개입니다.
- 현재는 evaluation 함수가 indexing만 지원하고 있기 때문에 이대로 코드 작업 시 충돌이 날 가능성이 높습니다.
- 그에 맞춰 미리 분기처리 해둡니다.

**실행 방법**
1. index: `python -m graphrag evaluate --method index --root-exp onepiece_rag --root-ctl onepiece_rag`
2. query: `python -m graphrag evaluate --method query --root-exp onepiece_rag`
3. both: `python -m graphrag evaluate --method both --root-exp onepiece_rag --root-ctl onepiece_rag`

## 작업 내용

- evaluation cli 실행 시, mode 설정을 통해 원하는 evaluation을 할 수 있도록 수정합니다.
- both mode도 있는데, 이는 index 후 query 성능도 평가하는 방식입니다.
- evaluation의 잡다한 리팩토링도 겸사겸사 진행합니다.
- [PRD](https://www.notion.so/MAP-MApping-a-Paper-15bd2f288baf805fb899fe87939b1c17?p=1b9d2f288baf80ff9e48ca45423e98a1&pm=s)
