### PR TITLE
add: incorporate test-set generation pipeline

### DIFF
--- a/graphrag/cli/main.py
+++ b/graphrag/cli/main.py
@@ -580,3 +580,46 @@ def _evaluate_cli(
                 response_type=response_type,
                 dry_run=dry_run,
             )
+
+@app.command("testset-gen")
+def _testset_gen_cli(
+    config: Annotated[
+        Path | None,
+        typer.Option(
+            help="The configuration to use.", exists=True, file_okay=True, readable=True
+        ),
+    ] = None,
+    root: Annotated[
+        Path,
+        typer.Option(
+            help="The project root directory.",
+            exists=True,
+            dir_okay=True,
+            writable=True,
+            resolve_path=True,
+            autocompletion=path_autocomplete(
+                file_okay=False, dir_okay=True, match_wildcard="*"
+            ),
+        ),
+    ] = Path(),  # set default to current directory
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            help="Run the indexing pipeline without executing any steps to inspect and validate the configuration."
+        ),
+    ] = False,
+    testset_size: Annotated[
+        int,
+        typer.Option(
+            help="Size of the test set."
+        ),
+    ] = 10,
+):
+    from graphrag.cli.test import testset_gen
+
+    testset_gen(
+        config_filepath=config,
+        root=root,
+        dry_run=dry_run,
+        testset_size=testset_size,
+    )

--- a/graphrag/cli/test.py
+++ b/graphrag/cli/test.py
@@ -48,37 +48,3 @@ def testset_gen(
     save_name = os.path.join(root, 'test_set.csv')
     df = dataset.to_pandas()
     df.to_csv(save_name)
-
-def testset_gen(
-        config_filepath: Path | None,
-        root: Path,
-        dry_run: bool,
-        testset_size: int = 10
-):
-    root = root.resolve()
-    config = load_config(root, config_filepath)
-
-    # api key setting for langchain-openai
-    os.environ["OPENAI_API_KEY"] = config.llm.api_key
-
-    # initialize generator & embedder
-    generator_llm = LangchainLLMWrapper(ChatOpenAI(model=config.llm.model))
-    generator_embeddings = LangchainEmbeddingsWrapper(OpenAIEmbeddings(model=config.embeddings.llm.model))
-
-    # get data
-    path = os.path.join(root, 'input')
-    loader = DirectoryLoader(path, glob='*.txt', loader_cls=TextLoader)
-    docs = loader.load()
-
-    if dry_run:
-        logger.success("Dry run complete, exiting...")
-        sys.exit(0)
-
-    # build dataset generator
-    generator = TestsetGenerator(llm=generator_llm, embedding_model=generator_embeddings)
-    dataset = generator.generate_with_langchain_docs(docs, testset_size=testset_size)
-
-    # save
-    save_name = os.path.join(root, 'test_set.csv')
-    df = dataset.to_pandas()
-    df.to_csv(save_name)

--- a/graphrag/cli/test.py
+++ b/graphrag/cli/test.py
@@ -1,0 +1,84 @@
+import os
+import sys
+from pathlib import Path
+
+from graphrag.config.load_config import load_config
+from graphrag.logger.print_progress import PrintProgressLogger
+
+from ragas.llms import LangchainLLMWrapper
+from ragas.testset import TestsetGenerator
+from ragas.embeddings import LangchainEmbeddingsWrapper
+
+from langchain_openai import ChatOpenAI
+from langchain_openai import OpenAIEmbeddings
+from langchain_community.document_loaders import DirectoryLoader, TextLoader
+
+logger = PrintProgressLogger("")
+
+def testset_gen(
+        config_filepath: Path | None,
+        root: Path,
+        dry_run: bool,
+        testset_size: int = 10
+):
+    root = root.resolve()
+    config = load_config(root, config_filepath)
+
+    # api key setting for langchain-openai
+    os.environ["OPENAI_API_KEY"] = config.llm.api_key
+
+    # initialize generator & embedder
+    generator_llm = LangchainLLMWrapper(ChatOpenAI(model=config.llm.model))
+    generator_embeddings = LangchainEmbeddingsWrapper(OpenAIEmbeddings(model=config.embeddings.llm.model))
+
+    # get data
+    path = os.path.join(root, 'input')
+    loader = DirectoryLoader(path, glob='*.txt', loader_cls=TextLoader)
+    docs = loader.load()
+
+    if dry_run:
+        logger.success("Dry run complete, exiting...")
+        sys.exit(0)
+
+    # build dataset generator
+    generator = TestsetGenerator(llm=generator_llm, embedding_model=generator_embeddings)
+    dataset = generator.generate_with_langchain_docs(docs, testset_size=testset_size)
+
+    # save
+    save_name = os.path.join(root, 'test_set.csv')
+    df = dataset.to_pandas()
+    df.to_csv(save_name)
+
+def testset_gen(
+        config_filepath: Path | None,
+        root: Path,
+        dry_run: bool,
+        testset_size: int = 10
+):
+    root = root.resolve()
+    config = load_config(root, config_filepath)
+
+    # api key setting for langchain-openai
+    os.environ["OPENAI_API_KEY"] = config.llm.api_key
+
+    # initialize generator & embedder
+    generator_llm = LangchainLLMWrapper(ChatOpenAI(model=config.llm.model))
+    generator_embeddings = LangchainEmbeddingsWrapper(OpenAIEmbeddings(model=config.embeddings.llm.model))
+
+    # get data
+    path = os.path.join(root, 'input')
+    loader = DirectoryLoader(path, glob='*.txt', loader_cls=TextLoader)
+    docs = loader.load()
+
+    if dry_run:
+        logger.success("Dry run complete, exiting...")
+        sys.exit(0)
+
+    # build dataset generator
+    generator = TestsetGenerator(llm=generator_llm, embedding_model=generator_embeddings)
+    dataset = generator.generate_with_langchain_docs(docs, testset_size=testset_size)
+
+    # save
+    save_name = os.path.join(root, 'test_set.csv')
+    df = dataset.to_pandas()
+    df.to_csv(save_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,3 +109,7 @@ pre-commit==4.1.0 ; python_version >= "3.10" and python_version < "3.13"
 flask==3.1.0 ; python_version >= "3.10" and python_version < "3.13"
 flask_cors==5.0.0 ; python_version >= "3.10" and python_version < "3.13"
 flask_socketio==5.5.1 ; python_version >= "3.10" and python_version < "3.13"
+langchain-community
+langchain-openai
+ragas
+rapidfuzz


### PR DESCRIPTION
## 개요

- RAG 성능평가를 위한 Testset Generation 생성 파이프라인

## 작업 내용

- 사용방법: python3 -m graphrag testset-gen --root {root_path}
- 결과: root 디렉토리에 test_set.csv 생성 (default=10개)

- dependency에 langchain, ragas, 그 외 기반 모듈들 추가